### PR TITLE
Implemented IterableExtensions.reject

### DIFF
--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.xbase.tests.lib;
 
 import static com.google.common.collect.Lists.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -194,6 +195,46 @@ public class IterableExtensionsTest extends BaseIterablesIteratorsTest<Iterable<
 		assertEquals(new Pair<Integer, String>(1, "bar"), result.next());
 		assertFalse(result.hasNext());
 	}
-
 	
+	@Test public void testReject() {
+		Function1<Integer, Boolean> function = new Function1<Integer, Boolean>() {
+			@Override
+			public Boolean apply(Integer p) {
+				return p % 2 == 0;
+			}
+		};
+		assertEquals(newArrayList(1,3,5),newArrayList(IterableExtensions.reject(newArrayList(1,2,3,4,5), function)));
+		Function1<Integer, Boolean> functionNullSafe = new Function1<Integer, Boolean>() {
+			@Override
+			public Boolean apply(Integer p) {
+				return p == null || p % 2 == 0;
+			}
+		};
+		assertEquals(newArrayList(1,5),newArrayList(IterableExtensions.reject(newArrayList(1,2,null,4,5), functionNullSafe)));
+		try {
+			newArrayList(IterableExtensions.reject(null, function));
+			fail("NullPointerException expected");
+		} catch (NullPointerException e) {
+			// expected NPE
+		}
+		try {
+			newArrayList(IterableExtensions.reject(newArrayList(1,2,3), null));
+			fail("NullPointerException expected");
+		} catch (NullPointerException e) {
+			// expected NPE
+		}
+		Function1<Integer, Boolean> brokenFunction = new Function1<Integer, Boolean>() {
+			@Override
+			public Boolean apply(Integer p) {
+				return null;
+			}
+		};
+		try {
+			newArrayList(IterableExtensions.reject(newArrayList(1,2,3), brokenFunction));
+			fail("NullPointerException expected");
+		} catch (NullPointerException e) {
+			// expected NPE
+		}
+	}
+
 }

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
@@ -312,5 +312,46 @@ public class IteratorExtensionsTest extends BaseIterablesIteratorsTest<Iterator<
 		List<Pair<Integer, String>> pairs = new ArrayList<Pair<Integer, String>>();
 		Function1<Pair<Integer, String>, Integer> computeKeys = null;
 		IteratorExtensions.groupBy(pairs.iterator(), computeKeys);
-	}	
+	}
+
+	@Test public void testReject() {
+		Function1<Integer, Boolean> function = new Function1<Integer, Boolean>() {
+			@Override
+			public Boolean apply(Integer p) {
+				return p % 2 == 0;
+			}
+		};
+		assertEquals(newArrayList(1,3,5),newArrayList(IteratorExtensions.reject(newArrayList(1,2,3,4,5).iterator(), function)));
+		Function1<Integer, Boolean> functionNullSafe = new Function1<Integer, Boolean>() {
+			@Override
+			public Boolean apply(Integer p) {
+				return p == null || p % 2 == 0;
+			}
+		};
+		assertEquals(newArrayList(1,5),newArrayList(IteratorExtensions.reject(newArrayList(1,2,null,4,5).iterator(), functionNullSafe)));
+		try {
+			newArrayList(IteratorExtensions.reject(null, function));
+			fail("NullPointerException expected");
+		} catch (NullPointerException e) {
+			// expected NPE
+		}
+		try {
+			newArrayList(IteratorExtensions.reject(newArrayList(1,2,3).iterator(), null));
+			fail("NullPointerException expected");
+		} catch (NullPointerException e) {
+			// expected NPE
+		}
+		Function1<Integer, Boolean> brokenFunction = new Function1<Integer, Boolean>() {
+			@Override
+			public Boolean apply(Integer p) {
+				return null;
+			}
+		};
+		try {
+			newArrayList(IteratorExtensions.reject(newArrayList(1,2,3).iterator(), brokenFunction));
+			fail("NullPointerException expected");
+		} catch (NullPointerException e) {
+			// expected NPE
+		}
+	}
 }

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -254,6 +254,24 @@ public class IterableExtensions {
 	}
 
 	/**
+	 * Returns the elements of {@code unfiltered} that do not satisfy a predicate. The resulting iterable's iterator does not
+	 * support {@code remove()}. The returned iterable is a view on the original elements. Changes in the unfiltered
+	 * original are reflected in the view.
+	 *
+	 * @param unfiltered
+	 *            the unfiltered iterable. May not be <code>null</code>.
+	 * @param predicate
+	 *            the predicate. May not be <code>null</code>.
+	 * @return an iterable that contains only the elements that do not fulfill the predicate. Never <code>null</code>.
+	 *
+	 * @since 2.11
+	 */
+	@Pure
+	public static <T> Iterable<T> reject(Iterable<T> unfiltered, Function1<? super T, Boolean> predicate) {
+		return Iterables.filter(unfiltered, Predicates.not(new BooleanFunctionDelegate<T>(predicate)));
+	}
+
+	/**
 	 * Returns all instances of class {@code type} in {@code unfiltered}. The returned iterable has elements whose class
 	 * is {@code type} or a subclass of {@code type}. The returned iterable's iterator does not support {@code remove()}
 	 * . The returned iterable is a view on the original elements. Changes in the unfiltered original are reflected in

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
@@ -298,6 +298,22 @@ import com.google.common.collect.Sets;
 	}
 
 	/**
+	 * Returns the elements of {@code unfiltered} that do not satisfy a predicate. The resulting iterator does not
+	 * support {@code remove()}. The returned iterator is a view on the original elements. Changes in the unfiltered
+	 * original are reflected in the view.
+	 *
+	 * @param unfiltered
+	 *            the unfiltered iterator. May not be <code>null</code>.
+	 * @param predicate
+	 *            the predicate. May not be <code>null</code>.
+	 * @return an iterator that contains only the elements that do not fulfill the predicate. Never <code>null</code>.
+	 */
+	@Pure
+	public static <T> Iterator<T> reject(Iterator<T> unfiltered, Function1<? super T, Boolean> predicate) {
+		return Iterators.filter(unfiltered, Predicates.not(new BooleanFunctionDelegate<T>(predicate)));
+	}
+
+	/**
 	 * Returns all instances of class {@code type} in {@code unfiltered}. The returned iterator has elements whose class
 	 * is {@code type} or a subclass of {@code type}. The returned iterator does not support {@code remove()}.
 	 * The returned iterator is a view on the original elements. Changes in the unfiltered original are reflected in


### PR DESCRIPTION
Implemented IterableExtensions/IteratorExtensions.reject

https://bugs.eclipse.org/bugs/show_bug.cgi?id=382213

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>