### PR TITLE
Added specific primitive wrapped array implementations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-ext.buildTime = new java.text.SimpleDateFormat('yyyyMMddHHmm').format(new Date())
+ext.buildTime = new java.text.SimpleDateFormat('yyyyMMdd-HHmm').format(new Date())
 
 subprojects {
 	repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+ext.buildTime = new java.text.SimpleDateFormat('yyyyMMddHHmm').format(new Date())
+
 subprojects {
 	repositories {
 		jcenter()
@@ -11,6 +13,7 @@ subprojects {
 	apply from: "${rootDir}/gradle/eclipse-project-layout.gradle"
 	apply from: "${rootDir}/gradle/java-compiler-settings.gradle"
 	apply from: "${rootDir}/gradle/maven-deployment.gradle"
+	apply from: "${rootDir}/gradle/manifest-gen.gradle"
 }
 
 task cleanLocalMavenRepo(type: Delete) {

--- a/gradle/eclipse-project-layout.gradle
+++ b/gradle/eclipse-project-layout.gradle
@@ -25,9 +25,6 @@ jar {
 	from ('.') {
 		include 'about*.*', 'plugin.xml', 'schema/**', 'model/**'
 	}
-	metaInf {
-		from 'META-INF'
-	}
 }
 
 if (isTestProject)

--- a/gradle/manifest-gen.gradle
+++ b/gradle/manifest-gen.gradle
@@ -1,6 +1,7 @@
 def baseVersion = project.version
 if (baseVersion.endsWith('-SNAPSHOT'))
 	baseVersion = baseVersion.substring(0, baseVersion.length() - 9)
+def qualifiedVersion = baseVersion + '.v' + buildTime
 
 //------------------------------------------------------
 // Copy the existing manifest and insert the qualifier
@@ -12,7 +13,7 @@ task genManifest(type: Copy) {
     into "$buildDir/tmp/jar/"
     doLast {
     	def f = new File(manifestFile)
-    	def modifiedText = f.text.replace(baseVersion + '.qualifier', baseVersion + '.' + buildTime)
+    	def modifiedText = f.text.replace(baseVersion + '.qualifier', qualifiedVersion)
     	def writer = new PrintWriter(f)
     	writer.print(modifiedText)
     	writer.close()
@@ -39,10 +40,10 @@ task genSourcesManifest << {
 	writer.println('Manifest-Version: 1.0')
 	writer.println('Bundle-ManifestVersion: 2')
 	writer.println('Bundle-SymbolicName: ' + project.name + '.source')
-	writer.println('Bundle-Version: ' + baseVersion + '.' + buildTime)
+	writer.println('Bundle-Version: ' + qualifiedVersion)
 	writer.println('Bundle-Name: Sources')
 	writer.println('Bundle-Vendor: Eclipse Xtext')
-	writer.println('Eclipse-SourceBundle: ' + project.name + ';version="' + baseVersion + '.' + buildTime + '"')
+	writer.println('Eclipse-SourceBundle: ' + project.name + ';version="' + qualifiedVersion + '"')
 	writer.close()
 }
 genSourcesManifest.outputs.file(sourcesManifestFile)

--- a/gradle/manifest-gen.gradle
+++ b/gradle/manifest-gen.gradle
@@ -1,0 +1,56 @@
+def baseVersion = project.version
+if (baseVersion.endsWith('-SNAPSHOT'))
+	baseVersion = baseVersion.substring(0, baseVersion.length() - 9)
+
+//------------------------------------------------------
+// Copy the existing manifest and insert the qualifier
+
+def manifestFile = "$buildDir/tmp/jar/MANIFEST.MF"
+
+task genManifest(type: Copy) {
+    from "META-INF/MANIFEST.MF"
+    into "$buildDir/tmp/jar/"
+    doLast {
+    	def f = new File(manifestFile)
+    	def modifiedText = f.text.replace(baseVersion + '.qualifier', baseVersion + '.' + buildTime)
+    	def writer = new PrintWriter(f)
+    	writer.print(modifiedText)
+    	writer.close()
+    }
+}
+
+jar {
+	dependsOn genManifest
+	inputs.file(manifestFile)
+	manifest {
+		from manifestFile
+	}
+}
+
+//------------------------------------------------------
+// Generate a manifest for the source bundle
+
+def sourcesManifestFile = "$buildDir/tmp/sourcesJar/MANIFEST.MF"
+
+task genSourcesManifest << {
+	def f = new File(sourcesManifestFile)
+	f.parentFile.mkdirs()
+	def writer = new PrintWriter(f)
+	writer.println('Manifest-Version: 1.0')
+	writer.println('Bundle-ManifestVersion: 2')
+	writer.println('Bundle-SymbolicName: ' + project.name + '.source')
+	writer.println('Bundle-Version: ' + baseVersion + '.' + buildTime)
+	writer.println('Bundle-Name: Sources')
+	writer.println('Bundle-Vendor: Eclipse Xtext')
+	writer.println('Eclipse-SourceBundle: ' + project.name + ';version="' + baseVersion + '.' + buildTime + '"')
+	writer.close()
+}
+genSourcesManifest.outputs.file(sourcesManifestFile)
+
+sourcesJar {
+	dependsOn genSourcesManifest
+	inputs.file(sourcesManifestFile)
+	manifest {
+		from sourcesManifestFile
+	}
+}

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -7,9 +7,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 	from ('.') {
 		include 'schema/**', 'model/**'
 	}
-	metaInf {
-		from 'META-INF'
-	}
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Conversions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Conversions.java
@@ -14,6 +14,12 @@ import java.util.RandomAccess;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.Iterables;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Floats;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 
 /**
  * This is a library used to convert arrays to lists and vice versa in a way that keeps the identity of the
@@ -24,8 +30,14 @@ import com.google.common.collect.Iterables;
  * 
  * @author Sebastian Zarnekow - Initial contribution and API
  * @author Sven Efftinge
+ * @author dustContributor
  */
-@GwtIncompatible("reflection") public class Conversions {
+@GwtIncompatible("reflection")
+public final class Conversions {
+
+	private Conversions() {
+		throw new RuntimeException("Can't create instances of this class");
+	}
 
 	/**
 	 * Wraps {@code object} in a list if and only if {@code object} is an array. Works for primitive and
@@ -38,23 +50,58 @@ import com.google.common.collect.Iterables;
 	 */
 	@Pure
 	public static Object doWrapArray(Object object) {
-		if (object == null)
+		if (object == null) {
+			// Nothing to wrap.
 			return null;
-		Class<?> arrayClass = object.getClass();
-		if (arrayClass.isArray()) {
-			if (arrayClass.getComponentType().isPrimitive()) {
-				WrappedPrimitiveArray result = WrappedPrimitiveArray.create(object);
-				return result;
-			}
-			WrappedArray<Object> result = WrappedArray.create((Object[]) object);
-			return result;
 		}
-		return object;
+
+		Class<?> arrayClass = object.getClass();
+
+		if (!arrayClass.isArray()) {
+			// Can't wrap something that isn't an array.
+			return object;
+		}
+
+		if (!arrayClass.getComponentType().isPrimitive()) {
+			// Not a primitive, return generic wrapped object array.
+			return WrappedArray.create((Object[]) object);
+		}
+
+		// Now check for each primitive type individually, and return the appropriate wrapper.
+
+		// These are probably the most used types, check for them first:
+		if (object instanceof int[]) {
+			return WrappedIntArray.create((int[]) object);
+		}
+
+		if (object instanceof long[]) {
+			return WrappedLongArray.create((long[]) object);
+		}
+
+		if (object instanceof float[]) {
+			return WrappedFloatArray.create((float[]) object);
+		}
+
+		if (object instanceof double[]) {
+			return WrappedDoubleArray.create((double[]) object);
+		}
+
+		// Now check for the slightly less used types:
+		if (object instanceof byte[]) {
+			return WrappedByteArray.create((byte[]) object);
+		}
+
+		if (object instanceof short[]) {
+			return WrappedShortArray.create((short[]) object);
+		}
+
+		// Unrecognized type.
+		return null;
 	}
 
 	/**
 	 * Unwraps {@code object} to extract the original array if and only if {@code object} was previously created by
-	 * {@link #doWrapArray(Object)}. If the array's component type cannot be determined at runtime, {@link Object} is  
+	 * {@link #doWrapArray(Object)}. If the array's component type cannot be determined at runtime, {@link Object} is
 	 * used.
 	 * 
 	 * @param value
@@ -66,7 +113,7 @@ import com.google.common.collect.Iterables;
 	public static Object unwrapArray(Object value) {
 		return unwrapArray(value, Object.class);
 	}
-	
+
 	/**
 	 * Unwraps {@code object} to extract the original array if and only if {@code object} was previously created by
 	 * {@link #doWrapArray(Object)}.
@@ -82,37 +129,67 @@ import com.google.common.collect.Iterables;
 	 */
 	@Pure
 	public static Object unwrapArray(Object value, Class<?> componentType) {
+		// This is the generic object array check.
 		if (value instanceof WrappedArray<?>) {
 			Object result = ((WrappedArray<?>) value).internalToArray();
 			return checkComponentType(result, componentType);
 		}
-		if (value instanceof WrappedPrimitiveArray) {
-			Object result = ((WrappedPrimitiveArray) value).internalToArray();
+		// And now for the primitive arrays.
+		if (value instanceof WrappedIntArray) {
+			Object result = ((WrappedIntArray) value).internalToArray();
 			return checkComponentType(result, componentType);
 		}
-		if (value instanceof Iterable<?>) {
-			if (!componentType.isPrimitive()) {
-				@SuppressWarnings({ "unchecked", "rawtypes" })
-				Object result = Iterables.toArray((Iterable)value, componentType);
-				return result;
-			} else {
-				try {
-					List<?> list = IterableExtensions.toList((Iterable<?>) value);
-					Object result = Array.newInstance(componentType, list.size());
-					for(int i = 0; i < list.size(); i++) {
-						Object element = list.get(i);
-						if (element == null) {
-							throw new ArrayStoreException("Cannot store <null> in primitive arrays.");
-						}
-						Array.set(result, i, element);
-					}
-					return result;
-				} catch(IllegalArgumentException iae) {
-					throw new ArrayStoreException("Primitive conversion failed: " + iae.getMessage());
-				}
-			}
+
+		if (value instanceof WrappedLongArray) {
+			Object result = ((WrappedLongArray) value).internalToArray();
+			return checkComponentType(result, componentType);
 		}
-		return value;
+
+		if (value instanceof WrappedFloatArray) {
+			Object result = ((WrappedFloatArray) value).internalToArray();
+			return checkComponentType(result, componentType);
+		}
+
+		if (value instanceof WrappedDoubleArray) {
+			Object result = ((WrappedDoubleArray) value).internalToArray();
+			return checkComponentType(result, componentType);
+		}
+
+		if (value instanceof WrappedByteArray) {
+			Object result = ((WrappedByteArray) value).internalToArray();
+			return checkComponentType(result, componentType);
+		}
+
+		if (value instanceof WrappedShortArray) {
+			Object result = ((WrappedShortArray) value).internalToArray();
+			return checkComponentType(result, componentType);
+		}
+
+		if (!(value instanceof Iterable<?>)) {
+			// Nothing to unwrap.
+			return value;
+		}
+
+		if (!componentType.isPrimitive()) {
+			@SuppressWarnings({ "unchecked", "rawtypes" })
+			Object result = Iterables.toArray((Iterable) value, componentType);
+			return result;
+		}
+
+		try {
+			List<?> list = IterableExtensions.toList((Iterable<?>) value);
+			Object result = Array.newInstance(componentType, list.size());
+			for (int i = 0; i < list.size(); i++) {
+				Object element = list.get(i);
+				if (element == null) {
+					throw new ArrayStoreException("Cannot store <null> in primitive arrays.");
+				}
+				Array.set(result, i, element);
+			}
+			return result;
+		} catch (IllegalArgumentException iae) {
+			throw new ArrayStoreException("Primitive conversion failed: " + iae.getMessage());
+		}
 	}
 
 	/**
@@ -129,9 +206,9 @@ import com.google.common.collect.Iterables;
 	private static Object checkComponentType(Object array, Class<?> expectedComponentType) {
 		Class<?> actualComponentType = array.getClass().getComponentType();
 		if (!expectedComponentType.isAssignableFrom(actualComponentType)) {
-			throw new ArrayStoreException(String.format(
-					"The expected component type %s is not assignable from the actual type %s", 
-					expectedComponentType.getCanonicalName(), actualComponentType.getCanonicalName()));
+			throw new ArrayStoreException(
+					String.format("The expected component type %s is not assignable from the actual type %s",
+							expectedComponentType.getCanonicalName(), actualComponentType.getCanonicalName()));
 		}
 		return array;
 	}
@@ -142,7 +219,7 @@ import com.google.common.collect.Iterables;
 	 * @param <T>
 	 *            the type if the list elements.
 	 */
-	public static class WrappedArray<T> extends AbstractList<T> implements RandomAccess {
+	public static final class WrappedArray<T> extends AbstractList<T> implements RandomAccess {
 
 		/**
 		 * Creates a new {@link WrappedArray} that is backed by the given {@code array}.
@@ -240,55 +317,50 @@ import com.google.common.collect.Iterables;
 	 * A list that is completely backed by an array of primitives and that provides access to that array. Only for
 	 * internal use.
 	 */
-	public static class WrappedPrimitiveArray extends AbstractList<Object> implements RandomAccess {
+	public static final class WrappedByteArray extends AbstractList<Byte> implements RandomAccess {
 
 		/**
-		 * Creates a new {@link WrappedPrimitiveArray} that is backed by the given primitive {@code array}.
-		 * 
+		 * Creates a new {@link WrappedByteArray} that is backed by the given primitive {@code array}.
+		 *
 		 * @param array
 		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the resulting
 		 *            object to fail.
 		 * @return the wrapped array. Never <code>null</code>.
 		 */
 		@Pure
-		public static WrappedPrimitiveArray create(Object array) {
-			return new WrappedPrimitiveArray(array);
+		public static WrappedByteArray create(byte[] array) {
+			return new WrappedByteArray(array);
 		}
 
-		private Object array;
-		private int size;
+		private final byte[] array;
 
 		/**
 		 * Internal constructor for {@link WrappedPrimitiveArray}.
-		 * 
+		 *
 		 * @param array
 		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the created
 		 *            object to fail with a {@link NullPointerException}.
 		 */
-		protected WrappedPrimitiveArray(Object array) {
+		protected WrappedByteArray(byte[] array) {
 			this.array = array;
-			if (array != null)
-				this.size = Array.getLength(array);
 		}
 
 		/**
 		 * {@inheritDoc}
-		 * 
+		 *
 		 * @throws NullPointerException
 		 *             if the wrapped array was <code>null</code>.
 		 * @throws IndexOutOfBoundsException
 		 *             {@inheritDoc}
 		 */
 		@Override
-		public Object get(int index) {
-			if (array == null)
-				throw new NullPointerException();
-			return Array.get(array, index);
+		public Byte get(int index) {
+			return Byte.valueOf(array[index]);
 		}
 
 		/**
 		 * {@inheritDoc}
-		 * 
+		 *
 		 * @throws NullPointerException
 		 *             if the wrapped array was <code>null</code>.
 		 * @throws ClassCastException
@@ -301,39 +373,813 @@ import com.google.common.collect.Iterables;
 		 *             {@inheritDoc}
 		 */
 		@Override
-		public Object set(int index, Object element) {
-			if (array == null)
-				throw new NullPointerException();
-			Object old = get(index);
-			Array.set(array, index, element);
+		public Byte set(int index, Byte element) {
 			modCount++;
-			return old;
+			byte old = array[index];
+			array[index] = element.byteValue();
+			return Byte.valueOf(old);
 		}
 
 		/**
 		 * {@inheritDoc}
-		 * 
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int indexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Byte) {
+				return Bytes.indexOf(array, ((Byte) o).byteValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int lastIndexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Byte) {
+				return Bytes.lastIndexOf(array, ((Byte) o).byteValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public boolean contains(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return false;
+			}
+			if (o instanceof Byte) {
+				return Bytes.contains(array, ((Byte) o).byteValue());
+			}
+			return false;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
 		 * @throws NullPointerException
 		 *             if the wrapped array was <code>null</code>.
 		 */
 		@Override
 		public int size() {
-			if (array == null)
-				throw new NullPointerException();
-			return size;
+			return array.length;
 		}
 
 		/**
 		 * Returns the underlying array in an unsafe manner. That is, modification of the array will be reflected by
 		 * this list and vice versa.
-		 * 
-		 * @return the underlying array. May be <code>null</code> if the list was {@link #create(Object) created} with a
+		 *
+		 * @return the underlying array. May be <code>null</code> if the list was {@link #create(byte[]) created} with a
 		 *         null argument.
 		 */
-		public Object internalToArray() {
+		public byte[] internalToArray() {
 			modCount++;
 			return array;
 		}
+	}
 
+	/**
+	 * A list that is completely backed by an array of primitives and that provides access to that array. Only for
+	 * internal use.
+	 */
+	public static final class WrappedShortArray extends AbstractList<Short> implements RandomAccess {
+
+		/**
+		 * Creates a new {@link WrappedShortArray} that is backed by the given primitive {@code array}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the resulting
+		 *            object to fail.
+		 * @return the wrapped array. Never <code>null</code>.
+		 */
+		@Pure
+		public static WrappedShortArray create(short[] array) {
+			return new WrappedShortArray(array);
+		}
+
+		private final short[] array;
+
+		/**
+		 * Internal constructor for {@link WrappedPrimitiveArray}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the created
+		 *            object to fail with a {@link NullPointerException}.
+		 */
+		protected WrappedShortArray(short[] array) {
+			this.array = array;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Short get(int index) {
+			return Short.valueOf(array[index]);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws ClassCastException
+		 *             {@inheritDoc}
+		 * @throws NullPointerException
+		 *             {@inheritDoc}
+		 * @throws IllegalArgumentException
+		 *             {@inheritDoc}
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Short set(int index, Short element) {
+			modCount++;
+			short old = array[index];
+			array[index] = element.shortValue();
+			return Short.valueOf(old);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int indexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Short) {
+				return Shorts.indexOf(array, ((Short) o).shortValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int lastIndexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Short) {
+				return Shorts.lastIndexOf(array, ((Short) o).shortValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public boolean contains(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return false;
+			}
+			if (o instanceof Short) {
+				return Shorts.contains(array, ((Short) o).shortValue());
+			}
+			return false;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int size() {
+			return array.length;
+		}
+
+		/**
+		 * Returns the underlying array in an unsafe manner. That is, modification of the array will be reflected by
+		 * this list and vice versa.
+		 *
+		 * @return the underlying array. May be <code>null</code> if the list was {@link #create(short[]) created} with
+		 *         a null argument.
+		 */
+		public short[] internalToArray() {
+			modCount++;
+			return array;
+		}
+	}
+
+	/**
+	 * A list that is completely backed by an array of primitives and that provides access to that array. Only for
+	 * internal use.
+	 */
+	public static final class WrappedIntArray extends AbstractList<Integer> implements RandomAccess {
+
+		/**
+		 * Creates a new {@link WrappedIntArray} that is backed by the given primitive {@code array}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the resulting
+		 *            object to fail.
+		 * @return the wrapped array. Never <code>null</code>.
+		 */
+		@Pure
+		public static WrappedIntArray create(int[] array) {
+			return new WrappedIntArray(array);
+		}
+
+		private final int[] array;
+
+		/**
+		 * Internal constructor for {@link WrappedPrimitiveArray}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the created
+		 *            object to fail with a {@link NullPointerException}.
+		 */
+		protected WrappedIntArray(int[] array) {
+			this.array = array;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Integer get(int index) {
+			return Integer.valueOf(array[index]);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws ClassCastException
+		 *             {@inheritDoc}
+		 * @throws NullPointerException
+		 *             {@inheritDoc}
+		 * @throws IllegalArgumentException
+		 *             {@inheritDoc}
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Integer set(int index, Integer element) {
+			modCount++;
+			int old = array[index];
+			array[index] = element.intValue();
+			return Integer.valueOf(old);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int indexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Integer) {
+				return Ints.indexOf(array, ((Integer) o).intValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int lastIndexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Integer) {
+				return Ints.lastIndexOf(array, ((Integer) o).intValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public boolean contains(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return false;
+			}
+			if (o instanceof Integer) {
+				return Ints.contains(array, ((Integer) o).intValue());
+			}
+			return false;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int size() {
+			return array.length;
+		}
+
+		/**
+		 * Returns the underlying array in an unsafe manner. That is, modification of the array will be reflected by
+		 * this list and vice versa.
+		 *
+		 * @return the underlying array. May be <code>null</code> if the list was {@link #create(int[]) created} with a
+		 *         null argument.
+		 */
+		public int[] internalToArray() {
+			modCount++;
+			return array;
+		}
+	}
+
+	/**
+	 * A list that is completely backed by an array of primitives and that provides access to that array. Only for
+	 * internal use.
+	 */
+	public static final class WrappedLongArray extends AbstractList<Long> implements RandomAccess {
+
+		/**
+		 * Creates a new {@link WrappedLongArray} that is backed by the given primitive {@code array}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the resulting
+		 *            object to fail.
+		 * @return the wrapped array. Never <code>null</code>.
+		 */
+		@Pure
+		public static WrappedLongArray create(long[] array) {
+			return new WrappedLongArray(array);
+		}
+
+		private final long[] array;
+
+		/**
+		 * Internal constructor for {@link WrappedPrimitiveArray}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the created
+		 *            object to fail with a {@link NullPointerException}.
+		 */
+		protected WrappedLongArray(long[] array) {
+			this.array = array;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Long get(int index) {
+			return Long.valueOf(array[index]);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws ClassCastException
+		 *             {@inheritDoc}
+		 * @throws NullPointerException
+		 *             {@inheritDoc}
+		 * @throws IllegalArgumentException
+		 *             {@inheritDoc}
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Long set(int index, Long element) {
+			modCount++;
+			long old = array[index];
+			array[index] = element.longValue();
+			return Long.valueOf(old);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int indexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Long) {
+				return Longs.indexOf(array, ((Long) o).longValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int lastIndexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Long) {
+				return Longs.lastIndexOf(array, ((Long) o).longValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public boolean contains(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return false;
+			}
+			if (o instanceof Long) {
+				return Longs.contains(array, ((Long) o).longValue());
+			}
+			return false;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int size() {
+			return array.length;
+		}
+
+		/**
+		 * Returns the underlying array in an unsafe manner. That is, modification of the array will be reflected by
+		 * this list and vice versa.
+		 *
+		 * @return the underlying array. May be <code>null</code> if the list was {@link #create(long[]) created} with a
+		 *         null argument.
+		 */
+		public long[] internalToArray() {
+			modCount++;
+			return array;
+		}
+	}
+
+	/**
+	 * A list that is completely backed by an array of primitives and that provides access to that array. Only for
+	 * internal use.
+	 */
+	public static final class WrappedFloatArray extends AbstractList<Float> implements RandomAccess {
+
+		/**
+		 * Creates a new {@link WrappedFloatArray} that is backed by the given primitive {@code array}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the resulting
+		 *            object to fail.
+		 * @return the wrapped array. Never <code>null</code>.
+		 */
+		@Pure
+		public static WrappedFloatArray create(float[] array) {
+			return new WrappedFloatArray(array);
+		}
+
+		private final float[] array;
+
+		/**
+		 * Internal constructor for {@link WrappedPrimitiveArray}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the created
+		 *            object to fail with a {@link NullPointerException}.
+		 */
+		protected WrappedFloatArray(float[] array) {
+			this.array = array;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Float get(int index) {
+			return Float.valueOf(array[index]);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws ClassCastException
+		 *             {@inheritDoc}
+		 * @throws NullPointerException
+		 *             {@inheritDoc}
+		 * @throws IllegalArgumentException
+		 *             {@inheritDoc}
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Float set(int index, Float element) {
+			modCount++;
+			float old = array[index];
+			array[index] = element.floatValue();
+			return Float.valueOf(old);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int indexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Float) {
+				return Floats.indexOf(array, ((Float) o).floatValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int lastIndexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Float) {
+				return Floats.lastIndexOf(array, ((Float) o).floatValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public boolean contains(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return false;
+			}
+			if (o instanceof Float) {
+				return Floats.contains(array, ((Float) o).floatValue());
+			}
+			return false;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int size() {
+			return array.length;
+		}
+
+		/**
+		 * Returns the underlying array in an unsafe manner. That is, modification of the array will be reflected by
+		 * this list and vice versa.
+		 *
+		 * @return the underlying array. May be <code>null</code> if the list was {@link #create(float[]) created} with
+		 *         a null argument.
+		 */
+		public float[] internalToArray() {
+			modCount++;
+			return array;
+		}
+	}
+
+	/**
+	 * A list that is completely backed by an array of primitives and that provides access to that array. Only for
+	 * internal use.
+	 */
+	public static final class WrappedDoubleArray extends AbstractList<Double> implements RandomAccess {
+
+		/**
+		 * Creates a new {@link WrappedDoubleArray} that is backed by the given primitive {@code array}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the resulting
+		 *            object to fail.
+		 * @return the wrapped array. Never <code>null</code>.
+		 */
+		@Pure
+		public static WrappedDoubleArray create(double[] array) {
+			return new WrappedDoubleArray(array);
+		}
+
+		private final double[] array;
+
+		/**
+		 * Internal constructor for {@link WrappedPrimitiveArray}.
+		 *
+		 * @param array
+		 *            the to-be-wrapped array. May be <code>null</code> which will cause any method on the created
+		 *            object to fail with a {@link NullPointerException}.
+		 */
+		protected WrappedDoubleArray(double[] array) {
+			this.array = array;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Double get(int index) {
+			return Double.valueOf(array[index]);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 * @throws ClassCastException
+		 *             {@inheritDoc}
+		 * @throws NullPointerException
+		 *             {@inheritDoc}
+		 * @throws IllegalArgumentException
+		 *             {@inheritDoc}
+		 * @throws IndexOutOfBoundsException
+		 *             {@inheritDoc}
+		 */
+		@Override
+		public Double set(int index, Double element) {
+			modCount++;
+			double old = array[index];
+			array[index] = element.doubleValue();
+			return Double.valueOf(old);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int indexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Double) {
+				return Doubles.indexOf(array, ((Double) o).doubleValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int lastIndexOf(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return -1;
+			}
+			if (o instanceof Double) {
+				return Doubles.lastIndexOf(array, ((Double) o).doubleValue());
+			}
+			return -1;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public boolean contains(Object o) {
+			// Will make the method fail if array is null.
+			if (size() < 1) {
+				return false;
+			}
+			if (o instanceof Double) {
+				return Doubles.contains(array, ((Double) o).doubleValue());
+			}
+			return false;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @throws NullPointerException
+		 *             if the wrapped array was <code>null</code>.
+		 */
+		@Override
+		public int size() {
+			return array.length;
+		}
+
+		/**
+		 * Returns the underlying array in an unsafe manner. That is, modification of the array will be reflected by
+		 * this list and vice versa.
+		 *
+		 * @return the underlying array. May be <code>null</code> if the list was {@link #create(double[]) created} with
+		 *         a null argument.
+		 */
+		public double[] internalToArray() {
+			modCount++;
+			return array;
+		}
 	}
 }

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Conversions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Conversions.java
@@ -30,7 +30,7 @@ import com.google.common.primitives.Shorts;
  * 
  * @author Sebastian Zarnekow - Initial contribution and API
  * @author Sven Efftinge
- * @author dustContributor
+ * @author Facundo Etchezar - Initial implementation of the type-specific primitive array wrappers
  */
 @GwtIncompatible("reflection")
 public final class Conversions {


### PR DESCRIPTION
Well there it is. Turns out Guava's primitive array wrappers don't have the equivalent of "internalToArray" method, so I had to do my own implementation to allow for that. It also incorporates custom implementations for some methods to avoid boxing/unboxing when possible.

I also made the Conversions class final and with a private constructor, doesn't seems like a good idea to have that around as non-final/instantiable when its just used for static utility methods.

Wrapper classes are also final now.

Do you have tests to run against this? I haven't tested it.