### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Delegate.xtend
+++ b/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Delegate.xtend
@@ -113,7 +113,7 @@ class DelegateProcessor implements TransformationParticipant<MutableMemberDeclar
 		}
 
 		def hasValidType(MemberDeclaration it) {
-			if (type == null || type.inferred) {
+			if (type === null || type.inferred) {
 				addError("Cannot use inferred types on delegates")
 				false
 			} else {
@@ -216,7 +216,7 @@ class DelegateProcessor implements TransformationParticipant<MutableMemberDeclar
 
 		def getMethodsToImplement(MemberDeclaration delegate) {
 			delegate.delegatedInterfaces.map[declaredResolvedMethods].flatten
-				.filter[delegate.declaringType.findDeclaredMethod(declaration.simpleName, resolvedParameters.map[resolvedType]) == null]
+				.filter[delegate.declaringType.findDeclaredMethod(declaration.simpleName, resolvedParameters.map[resolvedType]) === null]
 				.filter[!isObjectMethod]
 				.groupBy[simpleSignature].values.map[head]
 				.toSet

--- a/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/FinalFieldsConstructor.xtend
+++ b/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/FinalFieldsConstructor.xtend
@@ -88,7 +88,7 @@ class FinalFieldsConstructorProcessor implements TransformationParticipant<Mutab
 		}
 
 		def getFinalFields(MutableTypeDeclaration it) {
-			declaredFields.filter[!static && final == true && initializer == null && thePrimaryGeneratedJavaElement]
+			declaredFields.filter[!static && final == true && initializer === null && thePrimaryGeneratedJavaElement]
 		}
 
 		def needsFinalFieldConstructor(MutableClassDeclaration it) {
@@ -170,7 +170,7 @@ class FinalFieldsConstructorProcessor implements TransformationParticipant<Mutab
 
 		def getSuperConstructor(TypeDeclaration it) {
 			if (it instanceof ClassDeclaration) {
-				if (extendedClass == object || extendedClass == null)
+				if (extendedClass == object || extendedClass === null)
 					return null;
 				return extendedClass.declaredResolvedConstructors.head
 			} else {

--- a/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/DelegateProcessor.java
+++ b/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/DelegateProcessor.java
@@ -77,7 +77,7 @@ public class DelegateProcessor implements TransformationParticipant<MutableMembe
     
     public boolean hasValidType(final MemberDeclaration it) {
       boolean _xifexpression = false;
-      if ((Objects.equal(this.getType(it), null) || this.getType(it).isInferred())) {
+      if (((this.getType(it) == null) || this.getType(it).isInferred())) {
         boolean _xblockexpression = false;
         {
           this.context.addError(it, "Cannot use inferred types on delegates");
@@ -328,7 +328,7 @@ public class DelegateProcessor implements TransformationParticipant<MutableMembe
         };
         Iterable<TypeReference> _map_1 = IterableExtensions.map(_resolvedParameters, _function_2);
         MethodDeclaration _findDeclaredMethod = _declaringType.findDeclaredMethod(_simpleName, ((TypeReference[])Conversions.unwrapArray(_map_1, TypeReference.class)));
-        return Boolean.valueOf(Objects.equal(_findDeclaredMethod, null));
+        return Boolean.valueOf((_findDeclaredMethod == null));
       };
       Iterable<ResolvedMethod> _filter = IterableExtensions.<ResolvedMethod>filter(_flatten, _function_1);
       final Function1<ResolvedMethod, Boolean> _function_2 = (ResolvedMethod it) -> {

--- a/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/FinalFieldsConstructorProcessor.java
+++ b/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/FinalFieldsConstructorProcessor.java
@@ -63,7 +63,7 @@ public class FinalFieldsConstructorProcessor implements TransformationParticipan
     public Iterable<? extends MutableFieldDeclaration> getFinalFields(final MutableTypeDeclaration it) {
       Iterable<? extends MutableFieldDeclaration> _declaredFields = it.getDeclaredFields();
       final Function1<MutableFieldDeclaration, Boolean> _function = (MutableFieldDeclaration it_1) -> {
-        return Boolean.valueOf(((((!it_1.isStatic()) && (it_1.isFinal() == true)) && Objects.equal(it_1.getInitializer(), null)) && this.context.isThePrimaryGeneratedJavaElement(it_1)));
+        return Boolean.valueOf(((((!it_1.isStatic()) && (it_1.isFinal() == true)) && (it_1.getInitializer() == null)) && this.context.isThePrimaryGeneratedJavaElement(it_1)));
       };
       return IterableExtensions.filter(_declaredFields, _function);
     }
@@ -250,7 +250,7 @@ public class FinalFieldsConstructorProcessor implements TransformationParticipan
     
     public ResolvedConstructor getSuperConstructor(final TypeDeclaration it) {
       if ((it instanceof ClassDeclaration)) {
-        if ((Objects.equal(((ClassDeclaration)it).getExtendedClass(), this.context.getObject()) || Objects.equal(((ClassDeclaration)it).getExtendedClass(), null))) {
+        if ((Objects.equal(((ClassDeclaration)it).getExtendedClass(), this.context.getObject()) || (((ClassDeclaration)it).getExtendedClass() == null))) {
           return null;
         }
         TypeReference _extendedClass = ((ClassDeclaration)it).getExtendedClass();

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.xtend
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.xtend
@@ -271,7 +271,7 @@ final class ToStringBuilder {
 		do {
 			result += current.declaredFields
 			current = current.superclass
-		} while (current != null)
+		} while (current !== null)
 		return result
 	}
 
@@ -335,7 +335,7 @@ package class ToStringContext {
 	}
 
 	def boolean startProcessing(Object obj) {
-		currentlyProcessed.get.put(obj, Boolean.TRUE) == null
+		currentlyProcessed.get.put(obj, Boolean.TRUE) === null
 	}
 
 	def void endProcessing(Object obj) {

--- a/org.eclipse.xtext.xbase.lib/xtend-gen/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.java
+++ b/org.eclipse.xtext.xbase.lib/xtend-gen/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.java
@@ -431,7 +431,7 @@ public final class ToStringBuilder {
         Class<?> _superclass = current.getSuperclass();
         current = _superclass;
       }
-    } while((!Objects.equal(current, null)));
+    } while((current != null));
     return result;
   }
 }

--- a/org.eclipse.xtext.xbase.lib/xtend-gen/org/eclipse/xtext/xbase/lib/util/ToStringContext.java
+++ b/org.eclipse.xtext.xbase.lib/xtend-gen/org/eclipse/xtext/xbase/lib/util/ToStringContext.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.xbase.lib.util;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.base.Objects;
 import java.util.IdentityHashMap;
 
 /**
@@ -29,7 +28,7 @@ class ToStringContext {
   public boolean startProcessing(final Object obj) {
     IdentityHashMap<Object, Boolean> _get = ToStringContext.currentlyProcessed.get();
     Boolean _put = _get.put(obj, Boolean.TRUE);
-    return Objects.equal(_put, null);
+    return (_put == null);
   }
   
   public void endProcessing(final Object obj) {


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used.
Resolved compiler warnings

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>