### PR TITLE
[eclipse/xtext-umbrella#14] set skipXtendCompiler property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+skipXtendCompiler=true


### PR DESCRIPTION
Avoids a circular dependency when running the build from the umbrella's composite
