### PR TITLE
fixed broken classpath

### DIFF
--- a/org.eclipse.xtend.lib.gwt.test/build.gradle
+++ b/org.eclipse.xtend.lib.gwt.test/build.gradle
@@ -1,8 +1,6 @@
 buildscript {
 	repositories {
-		maven {
-			url 'http://dl.bintray.com/steffenschaefer/maven'
-		}
+		jcenter()
 	}
 	dependencies {
 		classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'


### PR DESCRIPTION
fixed broken classpath (gwt plugin is now on jcenter)
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>