### PR TITLE
Permit (but don't mandate) Guava versions up to v20

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -7,7 +7,7 @@ version = '2.12.0-SNAPSHOT'
 ext.versions = [
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '1.0.15',
-	'guava': '[14.0,19)',
+	'guava': '[14.0,21)',
 	'guice': '3.0',
 	'gwt': '2.7.0'
 ]


### PR DESCRIPTION
NB: Guava v20 is the last non-Java 8 integrated version.

PS, FYI: Pushing this further, to the just release v21, which is Java 8 integrated, is a lot less trivial (assuming that Xtend lib has to want to stick to gradle/java-compiler-settings.gradle which has sourceCompatibility = '1.6', which I'm assuming is a given.