### PR TITLE
Permit open upper bound Guava versions in MANIFEST.MF for OSGi

### DIFF
--- a/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 2.12.0.qualifier
 Export-Package: org.eclipse.xtend2.lib,
  org.eclipse.xtext.xbase.lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: com.google.guava;bundle-version="[14.0.0,19.0.0)"
+Require-Bundle: com.google.guava;bundle-version="14.0.0"
 Bundle-Vendor: %Vendor-Name
 

--- a/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Export-Package: org.eclipse.xtend2.lib;version="2.12.0",
  org.eclipse.xtext.xbase.lib;version="2.12.0",
  org.eclipse.xtext.xbase.lib.internal;x-internal:="true",
  org.eclipse.xtext.xbase.lib.util;version="2.12.0"
-Require-Bundle: com.google.guava;bundle-version="[14.0.0,19.0.0)";visibility:=reexport
+Require-Bundle: com.google.guava;bundle-version="14.0.0";visibility:=reexport
 Bundle-Vendor: Eclipse Xtext


### PR DESCRIPTION
This makes it possible to load this bundle into an OSGi Framework
which has more recent versions of Guava, which of course are
backward compatible (for the use xtend-lib makes...), instead
of being force to make different Guava versions available.

The lower bound minimal version stays at 14.0.0, as is, unchanged.