### PR TITLE
Increased guava version to include version 21.

### DIFF
--- a/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 2.12.0.qualifier
 Export-Package: org.eclipse.xtend2.lib,
  org.eclipse.xtext.xbase.lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: com.google.guava;bundle-version="[14.0.0,19.0.0)"
+Require-Bundle: com.google.guava;bundle-version="[14.0.0,22.0.0)"
 Bundle-Vendor: %Vendor-Name
 

--- a/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Export-Package: org.eclipse.xtend2.lib;version="2.12.0",
  org.eclipse.xtext.xbase.lib;version="2.12.0",
  org.eclipse.xtext.xbase.lib.internal;x-internal:="true",
  org.eclipse.xtext.xbase.lib.util;version="2.12.0"
-Require-Bundle: com.google.guava;bundle-version="[14.0.0,19.0.0)";visibility:=reexport
+Require-Bundle: com.google.guava;bundle-version="[14.0.0,22.0.0)";visibility:=reexport
 Bundle-Vendor: Eclipse Xtext


### PR DESCRIPTION
Increased guava version to include version 21.
https://github.com/eclipse/xtext-lib/issues/30

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>