### PR TITLE
Improved performance of newHashMap etc.

### DIFF
--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/CollectionLiterals.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/CollectionLiterals.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 
@@ -136,7 +135,9 @@ import com.google.common.primitives.Ints;
 	 */
 	@Pure
 	public static <T> ArrayList<T> newArrayList(T... initial) {
-		return Lists.newArrayList(initial);
+		if (initial.length > 0)
+			return Lists.newArrayList(initial);
+		return new ArrayList<T>();
 	}
 
 	/**
@@ -151,7 +152,7 @@ import com.google.common.primitives.Ints;
 	public static <T> LinkedList<T> newLinkedList(T... initial) {
 		if (initial.length > 0)
 			return Lists.newLinkedList(Arrays.asList(initial));
-		return Lists.newLinkedList();
+		return new LinkedList<T>();
 	}
 
 	/**
@@ -164,7 +165,9 @@ import com.google.common.primitives.Ints;
 	 */
 	@Pure
 	public static <T> HashSet<T> newHashSet(T... initial) {
-		return Sets.newHashSet(initial);
+		if (initial.length > 0)
+			return Sets.newHashSet(initial);
+		return new HashSet<T>();
 	}
 
 	/**
@@ -179,7 +182,7 @@ import com.google.common.primitives.Ints;
 	public static <T> LinkedHashSet<T> newLinkedHashSet(T... initial) {
 		if (initial.length > 0)
 			return Sets.newLinkedHashSet(Arrays.asList(initial));
-		return Sets.newLinkedHashSet();
+		return new LinkedHashSet<T>();
 	}
 
 	/**
@@ -268,7 +271,7 @@ import com.google.common.primitives.Ints;
 	 */
 	@Pure
 	public static <K, V> TreeMap<K, V> newTreeMap(Comparator<? super K> comparator, Pair<? extends K, ? extends V>... initial) {
-		TreeMap<K, V> result = Maps.newTreeMap(comparator);
+		TreeMap<K, V> result = new TreeMap<K, V>(comparator);
 		putAll(result, initial);
 		return result;
 	}

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/CollectionLiterals.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/CollectionLiterals.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
 
 /**
  * This is an extension library for {@link java.util.Collection collections}.
@@ -213,9 +214,12 @@ import com.google.common.collect.Sets;
 	 */
 	@Pure
 	public static <K, V> HashMap<K, V> newHashMap(Pair<? extends K, ? extends V>... initial) {
-		HashMap<K, V> result = Maps.newHashMapWithExpectedSize(initial.length);
-		putAll(result, initial);
-		return result;
+		if (initial.length > 0) {
+			HashMap<K, V> result = new HashMap<K, V>(capacity(initial.length));
+			putAll(result, initial);
+			return result;
+		}
+		return new HashMap<K, V>();
 	}
 
 	/**
@@ -231,9 +235,21 @@ import com.google.common.collect.Sets;
 	 */
 	@Pure
 	public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(Pair<? extends K, ? extends V>... initial) {
-		LinkedHashMap<K, V> result = new LinkedHashMap<K, V>(initial.length);
-		putAll(result, initial);
-		return result;
+		if (initial.length > 0) {
+			LinkedHashMap<K, V> result = new LinkedHashMap<K, V>(capacity(initial.length));
+			putAll(result, initial);
+			return result;
+		}
+		return new LinkedHashMap<K, V>();
+	}
+	
+	private static int capacity(int initialSize) {
+		if (initialSize < 3)
+			return initialSize + 1;
+		else if (initialSize < Ints.MAX_POWER_OF_TWO)
+			return initialSize + initialSize / 3;
+		else
+			return Integer.MAX_VALUE;
 	}
 
 	/**

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/CollectionLiterals.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/CollectionLiterals.java
@@ -126,6 +126,16 @@ import com.google.common.primitives.Ints;
 	}
 
 	/**
+	 * Creates an empty mutable {@link ArrayList} instance.
+	 * 
+	 * @return a new {@link ArrayList}
+	 */
+	@Pure
+	public static <T> ArrayList<T> newArrayList() {
+		return new ArrayList<T>();
+	}
+
+	/**
 	 * Creates a mutable {@link ArrayList} instance containing the given initial elements.
 	 * 
 	 * @param initial
@@ -137,7 +147,17 @@ import com.google.common.primitives.Ints;
 	public static <T> ArrayList<T> newArrayList(T... initial) {
 		if (initial.length > 0)
 			return Lists.newArrayList(initial);
-		return new ArrayList<T>();
+		return newArrayList();
+	}
+
+	/**
+	 * Creates an empty mutable {@link LinkedList} instance.
+	 * 
+	 * @return a new {@link LinkedList}
+	 */
+	@Pure
+	public static <T> LinkedList<T> newLinkedList() {
+		return new LinkedList<T>();
 	}
 
 	/**
@@ -152,7 +172,17 @@ import com.google.common.primitives.Ints;
 	public static <T> LinkedList<T> newLinkedList(T... initial) {
 		if (initial.length > 0)
 			return Lists.newLinkedList(Arrays.asList(initial));
-		return new LinkedList<T>();
+		return newLinkedList();
+	}
+
+	/**
+	 * Creates an empty mutable {@link HashSet} instance.
+	 * 
+	 * @return a new {@link HashSet}
+	 */
+	@Pure
+	public static <T> HashSet<T> newHashSet() {
+		return new HashSet<T>();
 	}
 
 	/**
@@ -167,7 +197,17 @@ import com.google.common.primitives.Ints;
 	public static <T> HashSet<T> newHashSet(T... initial) {
 		if (initial.length > 0)
 			return Sets.newHashSet(initial);
-		return new HashSet<T>();
+		return newHashSet();
+	}
+
+	/**
+	 * Creates an empty mutable {@link LinkedHashSet} instance.
+	 * 
+	 * @return a new {@link LinkedHashSet}
+	 */
+	@Pure
+	public static <T> LinkedHashSet<T> newLinkedHashSet() {
+		return new LinkedHashSet<T>();
 	}
 
 	/**
@@ -182,7 +222,20 @@ import com.google.common.primitives.Ints;
 	public static <T> LinkedHashSet<T> newLinkedHashSet(T... initial) {
 		if (initial.length > 0)
 			return Sets.newLinkedHashSet(Arrays.asList(initial));
-		return new LinkedHashSet<T>();
+		return newLinkedHashSet();
+	}
+
+	/**
+	 * Creates an empty mutable {@link TreeSet} instance.
+	 * 
+	 * @param comparator
+	 *            the comparator that should be used. May be <code>null</code> which indicates that the natural ordering
+	 *            of the items should be used.
+	 * @return a new {@link TreeSet}
+	 */
+	@Pure
+	public static <T> TreeSet<T> newTreeSet(Comparator<? super T> comparator) {
+		return new TreeSet<T>(comparator);
 	}
 
 	/**
@@ -205,6 +258,16 @@ import com.google.common.primitives.Ints;
 	}
 
 	/**
+	 * Creates an empty mutable {@link HashMap} instance.
+	 * 
+	 * @return a new {@link HashMap}
+	 */
+	@Pure
+	public static <K, V> HashMap<K, V> newHashMap() {
+		return new HashMap<K, V>();
+	}
+
+	/**
 	 * Creates a mutable {@link HashMap} instance containing the given initial entries. Repeated occurrences of a keys
 	 * will cause an {@link IllegalArgumentException}.
 	 * 
@@ -222,7 +285,17 @@ import com.google.common.primitives.Ints;
 			putAll(result, initial);
 			return result;
 		}
-		return new HashMap<K, V>();
+		return newHashMap();
+	}
+
+	/**
+	 * Creates an empty mutable {@link LinkedHashMap} instance.
+	 * 
+	 * @return a new {@link LinkedHashMap}
+	 */
+	@Pure
+	public static <K, V> LinkedHashMap<K, V> newLinkedHashMap() {
+		return new LinkedHashMap<K, V>();
 	}
 
 	/**
@@ -243,7 +316,7 @@ import com.google.common.primitives.Ints;
 			putAll(result, initial);
 			return result;
 		}
-		return new LinkedHashMap<K, V>();
+		return newLinkedHashMap();
 	}
 	
 	private static int capacity(int initialSize) {
@@ -253,6 +326,19 @@ import com.google.common.primitives.Ints;
 			return initialSize + initialSize / 3;
 		else
 			return Integer.MAX_VALUE;
+	}
+
+	/**
+	 * Creates an empty mutable {@link TreeMap} instance.
+	 * 
+	 * @param comparator
+	 *            the comparator that should be used. May be <code>null</code> which indicates that the natural ordering
+	 *            of the keys should be used.
+	 * @return a new {@link TreeMap}
+	 */
+	@Pure
+	public static <K, V> TreeMap<K, V> newTreeMap(Comparator<? super K> comparator) {
+		return new TreeMap<K, V>(comparator);
 	}
 
 	/**


### PR DESCRIPTION
 * When `newHashMap` or `newLinkedHashMap` is used without parameters, I would expect the same result that I get with `new HashMap` or `new LinkedHashMap`: maps initialized with the default capacity (16). Previously they were initialized with a capacity of 1, which means that rehashing was necessary even if you put just a few elements into them.

 * The `LinkedHashMap` constructor is now called with the capacity value, which is 4/3 &times; the initial size due to the load factor. Previously the initial size was used, which means that rehashing was necessary for the initial content.