### PR TITLE
[eclipse/xtext#1152] Java 9 - Added Automatic-Module-Name header

### DIFF
--- a/org.eclipse.xtend.lib.gwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.lib.gwt/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Bundle-Version: 2.14.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.xtend.lib
 Require-Bundle: org.eclipse.xtend.lib
+Automatic-Module-Name: org.eclipse.xtend.lib.gwt

--- a/org.eclipse.xtend.lib.macro/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.lib.macro/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Export-Package: org.eclipse.xtend.lib.macro;version="2.14.0";uses:="org.eclipse.
  org.eclipse.xtend.lib.macro.file;version="2.14.0",
  org.eclipse.xtend.lib.macro.services;version="2.14.0";uses:="org.eclipse.xtend.lib.macro.declaration,org.eclipse.xtext.xbase.lib"
 Require-Bundle: org.eclipse.xtext.xbase.lib;visibility:=reexport
+Automatic-Module-Name: org.eclipse.xtend.lib.macro

--- a/org.eclipse.xtend.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.lib/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Export-Package: org.eclipse.xtend.lib;version="2.14.0";uses:="org.eclipse.xtend.
  org.eclipse.xtend.lib.annotations;version="2.14.0";uses:="org.eclipse.xtend.lib.macro.declaration,org.eclipse.xtend2.lib,org.eclipse.xtend.lib.macro"
 Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.14.0";visibility:=reexport,
  org.eclipse.xtend.lib.macro;visibility:=reexport
+Automatic-Module-Name: org.eclipse.xtend.lib

--- a/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.guava;bundle-version="[14.0.0,22.0.0)"
 Bundle-Vendor: %Vendor-Name
 
+Automatic-Module-Name: org.eclipse.xtext.xbase.lib.gwt

--- a/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Export-Package: org.eclipse.xtend2.lib;version="2.14.0",
  org.eclipse.xtext.xbase.lib.util;version="2.14.0"
 Require-Bundle: com.google.guava;bundle-version="[14.0.0,22.0.0)";visibility:=reexport
 Bundle-Vendor: Eclipse Xtext
+Automatic-Module-Name: org.eclipse.xtext.xbase.lib


### PR DESCRIPTION
Signed-off-by: Florian Stolte <fstolte@itemis.de>