### PR TITLE
Fixed some tests that were failing on windows due to line endings

### DIFF
--- a/org.eclipse.xtend.lib.tests/src/org/eclipse/xtend/lib/annotations/DataTest.xtend
+++ b/org.eclipse.xtend.lib.tests/src/org/eclipse/xtend/lib/annotations/DataTest.xtend
@@ -2,19 +2,26 @@ package org.eclipse.xtend.lib.annotations
 
 import org.junit.Test
 import org.junit.Assert
+import org.eclipse.xtend2.lib.StringConcatenation
 
 class DataTest {
 	
 	@Test def void testData() {
-		Assert.assertEquals('''
+		Assert.assertEquals(toUnix('''
 			MyDataClass [
 			  arg = "foo"
 			  foo = false
-			]'''.toString, new MyDataClass("foo").toString)
+			]'''), new MyDataClass("foo").toString)
 	}
 	
 	@Data static class MyDataClass {
 		String arg
 		boolean foo = false
 	} 
+
+	def static String toUnix(String s) {
+		var StringConcatenation result = new StringConcatenation("\n")
+		result.append(s)
+		return result.toString()
+	}
 }

--- a/org.eclipse.xtend.lib.tests/xtend-gen/org/eclipse/xtend/lib/annotations/DataTest.java
+++ b/org.eclipse.xtend.lib.tests/xtend-gen/org/eclipse/xtend/lib/annotations/DataTest.java
@@ -82,6 +82,12 @@ public class DataTest {
     _builder.append("foo = false");
     _builder.newLine();
     _builder.append("]");
-    Assert.assertEquals(_builder.toString(), new DataTest.MyDataClass("foo").toString());
+    Assert.assertEquals(DataTest.toUnix(_builder.toString()), new DataTest.MyDataClass("foo").toString());
+  }
+  
+  public static String toUnix(final String s) {
+    StringConcatenation result = new StringConcatenation("\n");
+    result.append(s);
+    return result.toString();
   }
 }

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/StringConcatenationTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/StringConcatenationTest.java
@@ -147,7 +147,7 @@ public class StringConcatenationTest {
 
     @Test
     public void testNoindentConcat() {
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append("a\n");
         c.append("b\r");
         c.append("c\n");
@@ -156,7 +156,7 @@ public class StringConcatenationTest {
 
     @Test
     public void testIndentConcat() {
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append("a\n", " ");
         c.append("b\r", "  ");
         c.append("c\nd", "   ");
@@ -165,7 +165,7 @@ public class StringConcatenationTest {
 
     @Test
     public void testMaskedIndentConcat() {
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append((Object)"a\n", " ");
         c.append((Object)"b\r", "  ");
         c.append((Object)"c\nd", "   ");
@@ -174,7 +174,7 @@ public class StringConcatenationTest {
 
     @Test
     public void testObjectIndentConcat() {
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append(new StringObject("a\n"), " ");
         c.append(new StringObject("b\r"), "  ");
         c.append(new StringObject("c\nd"), "   ");
@@ -183,7 +183,7 @@ public class StringConcatenationTest {
 
     @Test
     public void testNewLine() {
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.newLine();
         c.append("a");
         c.newLine();
@@ -192,7 +192,7 @@ public class StringConcatenationTest {
 
     @Test
     public void testNewLineIfNotEmpty() {
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.newLineIfNotEmpty();
         c.append("a");
         c.newLineIfNotEmpty();
@@ -224,11 +224,11 @@ public class StringConcatenationTest {
 
     @Test
     public void testAppendConcat() {
-        final StringConcatenation toAppend = new StringConcatenation();
+        final StringConcatenation toAppend = new StringConcatenation("\n");
         toAppend.append("a\n");
         toAppend.append("b");
 
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append(toAppend);
         assertEquals("a\nb", c.toString());
     }
@@ -253,22 +253,22 @@ public class StringConcatenationTest {
 
     @Test
     public void testAppendMaskedConcat() {
-        final StringConcatenation toAppend = new StringConcatenation();
+        final StringConcatenation toAppend = new StringConcatenation("\n");
         toAppend.append("a\n");
         toAppend.append("b");
 
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append((Object)toAppend);
         assertEquals("a\nb", c.toString());
     }
 
     @Test
     public void testAppendMaskedIndentConcat() {
-        final StringConcatenation toAppend = new StringConcatenation();
+        final StringConcatenation toAppend = new StringConcatenation("\n");
         toAppend.append("a\n");
         toAppend.append("b");
 
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append((Object)toAppend, " ");
         assertEquals("a\n b", c.toString());
     }
@@ -282,7 +282,7 @@ public class StringConcatenationTest {
 
     @Test
     public void testAppendImmediateComplex() {
-        final StringConcatenation c = new StringConcatenation();
+        final StringConcatenation c = new StringConcatenation("\n");
         c.append("a\n");
         c.append(" b   ");
         c.newLineIfNotEmpty();


### PR DESCRIPTION
- StringConcatenationTest has hard-coded unix-style line endings, therefore the StringConcatenation must be set to unix-style line endings as well (instead of system-style)
- org.eclipse.xtend.lib.annotations.DataTest failed because ToStringBuilder always used unix-style line endings while test data used system-style line endings. Changed ToStringBuilder to use system-style line endings. I changed the implementation instead of the test since it seems logical to me that the ToStringBuilder should use system-style line endings.

Signed-off-by: Florian Stolte <fstolte@itemis.de>