### PR TITLE
Unnecessary variables

### DIFF
--- a/org.eclipse.xtend.lib.tests/xtend-gen/org/eclipse/xtend/lib/annotations/DataTest.java
+++ b/org.eclipse.xtend.lib.tests/xtend-gen/org/eclipse/xtend/lib/annotations/DataTest.java
@@ -26,8 +26,7 @@ public class DataTest {
       final int prime = 31;
       int result = 1;
       result = prime * result + ((this.arg== null) ? 0 : this.arg.hashCode());
-      result = prime * result + (this.foo ? 1231 : 1237);
-      return result;
+      return prime * result + (this.foo ? 1231 : 1237);
     }
     
     @Override

--- a/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Data.xtend
+++ b/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Data.xtend
@@ -50,7 +50,7 @@ class DataProcessor extends AbstractClassProcessor {
 		extension val requiredArgsUtil = new FinalFieldsConstructorProcessor.Util(context)
 
 		dataFields.forEach [
-			if ((primarySourceElement as FieldDeclaration).modifiers.contains(Modifier.VAR)){
+			if ((primarySourceElement as FieldDeclaration).modifiers.contains(Modifier.VAR)) {
 				addError("Cannot use the 'var' keyword on a data field")
 			}
 			final = true
@@ -82,7 +82,7 @@ class DataProcessor extends AbstractClassProcessor {
 	 * @since 2.7
 	 * @noextend
 	 * @noreference
- 	 */
+	 */
 	@Beta
 	static class Util {
 

--- a/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/EqualsHashCode.xtend
+++ b/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/EqualsHashCode.xtend
@@ -213,7 +213,7 @@ class EqualsHashCodeProcessor extends AbstractClassProcessor {
 				case Character.TYPE.name,
 				case Byte.TYPE.name,
 				case Short.TYPE.name:
-					'''this.«simpleName»;'''
+					'''this.«simpleName»'''
 				case Long.TYPE.name:
 					'''(int) (this.«simpleName» ^ (this.«simpleName» >>> 32))'''
 				default:

--- a/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/EqualsHashCode.xtend
+++ b/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/EqualsHashCode.xtend
@@ -62,6 +62,7 @@ class EqualsHashCodeProcessor extends AbstractClassProcessor {
 	@Beta
 	static class Util {
 
+		private static final int PRIME_VALUE = 31
 		extension TransformationContext context
 
 		new(TransformationContext context) {
@@ -176,20 +177,26 @@ class EqualsHashCodeProcessor extends AbstractClassProcessor {
 
 		def void addHashCode(MutableClassDeclaration cls, Iterable<? extends FieldDeclaration> includedFields,
 			boolean includeSuper) {
+			val defaultBase = if(includeSuper) "super.hashCode()" else "1"
+			val fields = includedFields.size
+
 			cls.addMethod("hashCode") [
 				primarySourceElement = cls.primarySourceElement
 				returnType = primitiveInt
 				addAnnotation(newAnnotationReference(Override))
 				addAnnotation(newAnnotationReference(Pure))
 				body = '''
-					«IF includedFields.size > 0»
-						final int prime = 31;
+					«IF fields >= 2»
+						final int prime = «PRIME_VALUE»;
+						int result = «defaultBase»;
+						«FOR i : 0 ..< fields»
+							«IF i == fields - 1»return«ELSE»result =«ENDIF» prime * result + «includedFields.get(i).contributeToHashCode»;
+						«ENDFOR»
+					«ELSEIF fields == 1»
+						return «PRIME_VALUE» * «defaultBase» + «includedFields.head.contributeToHashCode»;
+					«ELSE»
+						return «defaultBase»;
 					«ENDIF»
-					int result = «IF includeSuper»super.hashCode()«ELSE»1«ENDIF»;
-					«FOR field : includedFields»
-						«field.contributeToHashCode»
-					«ENDFOR»
-					return result;
 				'''
 			]
 		}
@@ -197,20 +204,20 @@ class EqualsHashCodeProcessor extends AbstractClassProcessor {
 		def StringConcatenationClient contributeToHashCode(FieldDeclaration it) {
 			switch (type.orObject.name) {
 				case Double.TYPE.name:
-					'''result = prime * result + (int) («Double».doubleToLongBits(this.«simpleName») ^ («Double».doubleToLongBits(this.«simpleName») >>> 32));'''
+					'''(int) («Double».doubleToLongBits(this.«simpleName») ^ («Double».doubleToLongBits(this.«simpleName») >>> 32))'''
 				case Float.TYPE.name:
-					'''result = prime * result + «Float».floatToIntBits(this.«simpleName»);'''
+					'''«Float».floatToIntBits(this.«simpleName»)'''
 				case Boolean.TYPE.name:
-					'''result = prime * result + (this.«simpleName» ? 1231 : 1237);'''
+					'''(this.«simpleName» ? 1231 : 1237)'''
 				case Integer.TYPE.name,
 				case Character.TYPE.name,
 				case Byte.TYPE.name,
 				case Short.TYPE.name:
-					'''result = prime * result + this.«simpleName»;'''
+					'''this.«simpleName»;'''
 				case Long.TYPE.name:
-					'''result = prime * result + (int) (this.«simpleName» ^ (this.«simpleName» >>> 32));'''
+					'''(int) (this.«simpleName» ^ (this.«simpleName» >>> 32))'''
 				default:
-					'''result = prime * result + ((this.«simpleName»== null) ? 0 : «deepHashCode»);'''
+					'''((this.«simpleName»== null) ? 0 : «deepHashCode»)'''
 			}
 		}
 		

--- a/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/ToString.xtend
+++ b/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/ToString.xtend
@@ -55,7 +55,7 @@ annotation ToString {
 	 * Only list the values of the fields, not their names
 	 */
 	val hideFieldNames = false
-	
+
 	/**
 	 * By default, Iterables, Arrays and multiline Strings are pretty-printed.
 	 * Switching to their normal representation makes the toString method significantly faster.
@@ -76,7 +76,7 @@ class ToStringConfiguration {
 	val boolean singleLine
 	val boolean hideFieldNames
 	val boolean verbatimValues
-	
+
 	new() {
 		this(false, false, false, false)
 	}
@@ -106,7 +106,7 @@ class ToStringConfiguration {
 	def isHideFieldNames() {
 		hideFieldNames
 	}
-	
+
 	def isVerbatimValues() {
 		verbatimValues
 	}
@@ -137,10 +137,10 @@ class ToStringProcessor extends AbstractClassProcessor {
 	}
 
 	/**
-	* @since 2.7
-	* @noextend
-	* @noreference
-	*/
+	 * @since 2.7
+	 * @noextend
+	 * @noreference
+	 */
 	@Beta
 	static class Util {
 		extension TransformationContext context
@@ -155,7 +155,7 @@ class ToStringProcessor extends AbstractClassProcessor {
 
 		def getToStringConfig(ClassDeclaration it) {
 			val anno = findAnnotation(ToString.findTypeGlobally)
-			if (anno === null) null else new ToStringConfiguration(anno)
+			if(anno === null) null else new ToStringConfiguration(anno)
 		}
 
 		def void addReflectiveToString(MutableClassDeclaration cls, ToStringConfiguration config) {
@@ -165,14 +165,13 @@ class ToStringProcessor extends AbstractClassProcessor {
 				addAnnotation(newAnnotationReference(Override))
 				addAnnotation(newAnnotationReference(Pure))
 				body = '''
-					String result = new «ToStringBuilder»(this)
+					return new «ToStringBuilder»(this)
 						.addAllFields()
 						«IF config.skipNulls».skipNulls()«ENDIF»
 						«IF config.singleLine».singleLine()«ENDIF»
 						«IF config.hideFieldNames».hideFieldNames()«ENDIF»
 						«IF config.verbatimValues».verbatimValues()«ENDIF»
 						.toString();
-					return result;
 				'''
 			]
 		}

--- a/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/EqualsHashCodeProcessor.java
+++ b/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/EqualsHashCodeProcessor.java
@@ -19,6 +19,7 @@ import org.eclipse.xtend.lib.macro.declaration.TypeParameterDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.TypeReference;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.ExclusiveRange;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
@@ -40,6 +41,8 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
    */
   @Beta
   public static class Util {
+    private final static int PRIME_VALUE = 31;
+    
     @Extension
     private TransformationContext context;
     
@@ -378,6 +381,14 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
     }
     
     public void addHashCode(final MutableClassDeclaration cls, final Iterable<? extends FieldDeclaration> includedFields, final boolean includeSuper) {
+      String _xifexpression = null;
+      if (includeSuper) {
+        _xifexpression = "super.hashCode()";
+      } else {
+        _xifexpression = "1";
+      }
+      final String defaultBase = _xifexpression;
+      final int fields = IterableExtensions.size(includedFields);
       final Procedure1<MutableMethodDeclaration> _function = (MutableMethodDeclaration it) -> {
         this.context.setPrimarySourceElement(it, this.context.getPrimarySourceElement(cls));
         it.setReturnType(this.context.getPrimitiveInt());
@@ -387,32 +398,51 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
           @Override
           protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
             {
-              int _size = IterableExtensions.size(includedFields);
-              boolean _greaterThan = (_size > 0);
-              if (_greaterThan) {
-                _builder.append("final int prime = 31;");
-                _builder.newLine();
-              }
-            }
-            _builder.append("int result = ");
-            {
-              if (includeSuper) {
-                _builder.append("super.hashCode()");
-              } else {
-                _builder.append("1");
-              }
-            }
-            _builder.append(";");
-            _builder.newLineIfNotEmpty();
-            {
-              for(final FieldDeclaration field : includedFields) {
-                StringConcatenationClient _contributeToHashCode = Util.this.contributeToHashCode(field);
-                _builder.append(_contributeToHashCode);
+              if ((fields >= 2)) {
+                _builder.append("final int prime = ");
+                _builder.append(EqualsHashCodeProcessor.Util.PRIME_VALUE);
+                _builder.append(";");
                 _builder.newLineIfNotEmpty();
+                _builder.append("int result = ");
+                _builder.append(defaultBase);
+                _builder.append(";");
+                _builder.newLineIfNotEmpty();
+                {
+                  ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, fields, true);
+                  for(final Integer i : _doubleDotLessThan) {
+                    {
+                      if (((i).intValue() == (fields - 1))) {
+                        _builder.append("return");
+                      } else {
+                        _builder.append("result =");
+                      }
+                    }
+                    _builder.append(" prime * result + ");
+                    StringConcatenationClient _contributeToHashCode = Util.this.contributeToHashCode(((FieldDeclaration[])Conversions.unwrapArray(includedFields, FieldDeclaration.class))[(i).intValue()]);
+                    _builder.append(_contributeToHashCode);
+                    _builder.append(";");
+                    _builder.newLineIfNotEmpty();
+                  }
+                }
+              } else {
+                if ((fields == 1)) {
+                  _builder.append("return ");
+                  _builder.append(EqualsHashCodeProcessor.Util.PRIME_VALUE);
+                  _builder.append(" * ");
+                  _builder.append(defaultBase);
+                  _builder.append(" + ");
+                  StringConcatenationClient _contributeToHashCode_1 = Util.this.contributeToHashCode(IterableExtensions.head(includedFields));
+                  _builder.append(_contributeToHashCode_1);
+                  _builder.append(";");
+                  _builder.newLineIfNotEmpty();
+                } else {
+                  _builder.append("return ");
+                  _builder.append(defaultBase);
+                  _builder.append(";");
+                  _builder.newLineIfNotEmpty();
+                }
               }
             }
-            _builder.append("return result;");
-            _builder.newLine();
           }
         };
         it.setBody(_client);
@@ -430,7 +460,7 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
         StringConcatenationClient _client = new StringConcatenationClient() {
           @Override
           protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-            _builder.append("result = prime * result + (int) (");
+            _builder.append("(int) (");
             _builder.append(Double.class);
             _builder.append(".doubleToLongBits(this.");
             String _simpleName = it.getSimpleName();
@@ -440,7 +470,7 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
             _builder.append(".doubleToLongBits(this.");
             String _simpleName_1 = it.getSimpleName();
             _builder.append(_simpleName_1);
-            _builder.append(") >>> 32));");
+            _builder.append(") >>> 32))");
           }
         };
         _switchResult = _client;
@@ -452,12 +482,11 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
           StringConcatenationClient _client_1 = new StringConcatenationClient() {
             @Override
             protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-              _builder.append("result = prime * result + ");
               _builder.append(Float.class);
               _builder.append(".floatToIntBits(this.");
               String _simpleName = it.getSimpleName();
               _builder.append(_simpleName);
-              _builder.append(");");
+              _builder.append(")");
             }
           };
           _switchResult = _client_1;
@@ -470,10 +499,10 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
           StringConcatenationClient _client_2 = new StringConcatenationClient() {
             @Override
             protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-              _builder.append("result = prime * result + (this.");
+              _builder.append("(this.");
               String _simpleName = it.getSimpleName();
               _builder.append(_simpleName);
-              _builder.append(" ? 1231 : 1237);");
+              _builder.append(" ? 1231 : 1237)");
             }
           };
           _switchResult = _client_2;
@@ -506,7 +535,7 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
           StringConcatenationClient _client_3 = new StringConcatenationClient() {
             @Override
             protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-              _builder.append("result = prime * result + this.");
+              _builder.append("this.");
               String _simpleName = it.getSimpleName();
               _builder.append(_simpleName);
               _builder.append(";");
@@ -522,13 +551,13 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
           StringConcatenationClient _client_4 = new StringConcatenationClient() {
             @Override
             protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-              _builder.append("result = prime * result + (int) (this.");
+              _builder.append("(int) (this.");
               String _simpleName = it.getSimpleName();
               _builder.append(_simpleName);
               _builder.append(" ^ (this.");
               String _simpleName_1 = it.getSimpleName();
               _builder.append(_simpleName_1);
-              _builder.append(" >>> 32));");
+              _builder.append(" >>> 32))");
             }
           };
           _switchResult = _client_4;
@@ -538,13 +567,13 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
         StringConcatenationClient _client_5 = new StringConcatenationClient() {
           @Override
           protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-            _builder.append("result = prime * result + ((this.");
+            _builder.append("((this.");
             String _simpleName = it.getSimpleName();
             _builder.append(_simpleName);
             _builder.append("== null) ? 0 : ");
             StringConcatenationClient _deepHashCode = Util.this.deepHashCode(it);
             _builder.append(_deepHashCode);
-            _builder.append(");");
+            _builder.append(")");
           }
         };
         _switchResult = _client_5;

--- a/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/EqualsHashCodeProcessor.java
+++ b/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/EqualsHashCodeProcessor.java
@@ -538,7 +538,6 @@ public class EqualsHashCodeProcessor extends AbstractClassProcessor {
               _builder.append("this.");
               String _simpleName = it.getSimpleName();
               _builder.append(_simpleName);
-              _builder.append(";");
             }
           };
           _switchResult = _client_3;

--- a/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/ToStringProcessor.java
+++ b/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/ToStringProcessor.java
@@ -74,7 +74,7 @@ public class ToStringProcessor extends AbstractClassProcessor {
         StringConcatenationClient _client = new StringConcatenationClient() {
           @Override
           protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-            _builder.append("String result = new ");
+            _builder.append("return new ");
             _builder.append(ToStringBuilder.class);
             _builder.append("(this)");
             _builder.newLineIfNotEmpty();
@@ -115,8 +115,6 @@ public class ToStringProcessor extends AbstractClassProcessor {
             _builder.newLineIfNotEmpty();
             _builder.append("\t");
             _builder.append(".toString();");
-            _builder.newLine();
-            _builder.append("return result;");
             _builder.newLine();
           }
         };


### PR DESCRIPTION
Removed unnecessary assignments in toString() and hashCode(). This is especially useful to avoid false positives in static analysis.