### PR TITLE
Added reject with only a Class argument

### DIFF
--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
@@ -197,6 +197,15 @@ public class IterableExtensionsTest extends BaseIterablesIteratorsTest<Iterable<
 	}
 	
 	@Test public void testReject() {
+		List<Integer> nullList = new ArrayList<>();
+		nullList.add(null);
+		List<Object> objects = newArrayList(1, 2, null, 4l, "String");
+		assertEquals(newArrayList(1, 2, null, 4l), newArrayList(IterableExtensions.reject(objects, String.class)));
+		assertEquals(nullList, newArrayList(IterableExtensions.reject(objects, Object.class)));
+		
+		List<Integer> integerObjects = newArrayList(1, 2, null, 4);
+		assertEquals(nullList, newArrayList(IterableExtensions.reject(integerObjects, Integer.class)));
+		
 		Function1<Integer, Boolean> function = new Function1<Integer, Boolean>() {
 			@Override
 			public Boolean apply(Integer p) {
@@ -218,7 +227,15 @@ public class IterableExtensionsTest extends BaseIterablesIteratorsTest<Iterable<
 			// expected NPE
 		}
 		try {
-			newArrayList(IterableExtensions.reject(newArrayList(1,2,3), null));
+			Function1<? super Integer, Boolean> nullFn = null;
+			newArrayList(IterableExtensions.reject(newArrayList(1,2,3), nullFn));
+			fail("NullPointerException expected");
+		} catch (NullPointerException e) {
+			// expected NPE
+		}
+		try {
+			Class<Integer> nullClass = null;
+			newArrayList(IterableExtensions.reject(newArrayList(1,2,3), nullClass));
 			fail("NullPointerException expected");
 		} catch (NullPointerException e) {
 			// expected NPE

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -272,6 +272,26 @@ public class IterableExtensions {
 	}
 
 	/**
+	 * Returns the elements of {@code unfiltered} that are not instanceof {@code type}. The resulting iterable's iterator does not
+	 * support {@code remove()}. The returned iterable is a view on the original elements. Changes in the unfiltered
+	 * original are reflected in the view.
+	 *
+	 * @param unfiltered
+	 *            the unfiltered iterable. May not be <code>null</code>.
+	* @param type
+	 *            the type of elements undesired. May not be <code>null</code>.
+	 * @return an iterable that contains only the elements that are not instances of {@code type}. Never <code>null</code>.
+	 *         Note that the elements of the iterable can be null as null is an instance of nothing.
+	 *
+	 * @since 2.15
+	 */
+	@GwtIncompatible("Class.isInstance")
+	@Pure
+	public static <T> Iterable<T> reject(Iterable<T> unfiltered, Class<? extends T> type) {
+		return filter(unfiltered, (t) -> !type.isInstance(t));
+	}
+
+	/**
 	 * Returns all instances of class {@code type} in {@code unfiltered}. The returned iterable has elements whose class
 	 * is {@code type} or a subclass of {@code type}. The returned iterable's iterator does not support {@code remove()}
 	 * . The returned iterable is a view on the original elements. Changes in the unfiltered original are reflected in


### PR DESCRIPTION
This API exists for filter, but not for reject