### PR TITLE
Make pure and inlinable the MapExtensions.mapValues function.

### DIFF
--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/MapExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/MapExtensions.java
@@ -413,6 +413,7 @@ import com.google.common.collect.Maps;
 	 * @return a map with equal keys but transformed values. Never <code>null</code>.
 	 * @since 2.4
 	 */
+	@Pure
 	public static <K, V1, V2> Map<K, V2> mapValues(Map<K, V1> original, Function1<? super V1, ? extends V2> transformation) {
 		return Maps.transformValues(original, new FunctionDelegate<V1, V2>(transformation));
 	}


### PR DESCRIPTION
The mapValues functions within MapExtensions could be annoted as pure
function because it has no border effect on its parameters.

It could also be inlined.

Signed-off-by: Stéphane Galland <galland@arakhne.org>