### PR TITLE
[eclipse/xtext#1270] use JavaSE-1.8 as BREE

### DIFF
--- a/org.eclipse.xtend.lib.gwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.lib.gwt/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.xtend.lib.gwt
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Version: 2.15.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend.lib
 Require-Bundle: org.eclipse.xtend.lib
 Automatic-Module-Name: org.eclipse.xtend.lib.gwt

--- a/org.eclipse.xtend.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.lib/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.xtend.lib
 Bundle-Name: Xtend Runtime Library
 Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.15.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend.lib;version="2.15.0";uses:="org.eclipse.xtend.lib.macro.declaration,org.eclipse.xtend.lib.macro",
  org.eclipse.xtend.lib.annotations;version="2.15.0";uses:="org.eclipse.xtend.lib.macro.declaration,org.eclipse.xtend2.lib,org.eclipse.xtend.lib.macro"
 Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.15.0";visibility:=reexport,

--- a/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.xtext.xbase.lib.gwt
 Bundle-Version: 2.15.0.qualifier
 Export-Package: org.eclipse.xtend2.lib,
  org.eclipse.xtext.xbase.lib
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava;bundle-version="[14.0.0,22.0.0)"
 Bundle-Vendor: %Vendor-Name
 Automatic-Module-Name: org.eclipse.xtext.xbase.lib.gwt

--- a/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xbase Runtime Library
 Bundle-SymbolicName: org.eclipse.xtext.xbase.lib
 Bundle-Version: 2.15.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend2.lib;version="2.15.0",
  org.eclipse.xtext.xbase.lib;version="2.15.0",
  org.eclipse.xtext.xbase.lib.internal;x-internal:="true",


### PR DESCRIPTION
[eclipse/xtext#1270] use JavaSE-1.8 as BREE
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>