### PR TITLE
[eclipse/xtext#1224] Detect local Jenkins environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node {
 	}
 	
 	stage('Gradle Build') {
-		sh "./gradlew clean cleanGenerateXtext build createLocalMavenRepo -PcompileXtend=true -PignoreTestFailures=true --refresh-dependencies --continue"
+		sh "./gradlew clean cleanGenerateXtext build createLocalMavenRepo -PcompileXtend=true -PJENKINS_URL=$JENKINS_URL -PignoreTestFailures=true --refresh-dependencies --continue"
 		step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/test/*.xml'])
 	}
 	
@@ -17,7 +17,7 @@ node {
 		env.M2_HOME = "${mvnHome}"
 		dir('.m2/repository/org/eclipse/xtext') { deleteDir() }
 		dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
-		sh "${mvnHome}/bin/mvn -f releng --batch-mode --update-snapshots -Dmaven.repo.local=.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install"
+		sh "${mvnHome}/bin/mvn -f releng --batch-mode --update-snapshots -Dmaven.repo.local=.m2/repository -DJENKINS_URL=$JENKINS_URL -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install"
 	}
 	
 	archive 'build/**'

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -1,13 +1,16 @@
 /*
  * Root project configuration that is reused by subprojects to apply the Xtend compiler.
  */
+if (!hasProperty('JENKINS_URL')) {
+	ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+}
 
 // The repositories to query when constructing the Xtend compiler classpath
 repositories {
 	jcenter()
 	maven {
 		name 'xtend-bootstrap'
-		url 'http://services.typefox.io/open-source/jenkins/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/'
+		url "$JENKINS_URL/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/"
 	}
 }
 


### PR DESCRIPTION
Build steps defined in Jenkinsfile pass the built-in environment
variable 'JENKINS_URL' to the Gradle/Maven executions. This is evaluated
in the build scripts for upstream repository URLs. On Xtext JIPP this
will use upstream repos from JIPP. In local builds outside of Jenkins
the property defaults to Typefox CI like before.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>