### PR TITLE
[eclipse/xtext#1309] Provide Jenkinsfile for Eclipse CBI

### DIFF
--- a/Jenkinsfile_CBI
+++ b/Jenkinsfile_CBI
@@ -1,0 +1,46 @@
+pipeline {
+	agent any
+
+	options {
+		buildDiscarder(logRotator(numToKeepStr:'15'))
+	}
+
+	tools { 
+		maven 'apache-maven-latest'
+		jdk 'oracle-jdk8-latest'
+	}
+	
+	// https://jenkins.io/doc/book/pipeline/syntax/#triggers
+	triggers {
+		pollSCM('H/5 * * * *')
+	}
+	
+	stages {
+		stage('Checkout') {
+			steps {
+				checkout scm
+			}
+		}
+
+		stage('Gradle Build') {
+			steps {
+				sh "./gradlew clean cleanGenerateXtext build createLocalMavenRepo -PcompileXtend=true -PJENKINS_URL=$JENKINS_URL -PignoreTestFailures=true --refresh-dependencies --continue"
+				step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/test/*.xml'])
+			}
+		}
+		
+		stage('Maven Build') {
+			steps {
+				dir('.m2/repository/org/eclipse/xtext') { deleteDir() }
+				dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
+				sh "mvn -f releng --batch-mode --update-snapshots -Dmaven.repo.local=.m2/repository -DJENKINS_URL=$JENKINS_URL -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install"
+			}
+		}
+	}
+
+	post {
+		success {
+			archiveArtifacts artifacts: 'build/**'
+		}
+	}
+}

--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -8,10 +8,15 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'ISO-8859-1'
 }
 
+tasks.withType(Test) {
+	systemProperty 'file.encoding', 'ISO-8859-1'
+}
+
 tasks.withType(Javadoc) {
 	options.encoding = 'ISO-8859-1'
 	options.tags = [ 'noreference', 'noextend', 'noimplement', 'noinstantiate', 'nooverride', 'model', 'generated', 'ordered' ] 
 	options.addStringOption('Xdoclint:none', '-quiet')
+	failOnError = false
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
Also:
- configure javadoc failOnError to false. Failed to resolve external
symbols on openjdk 10.
- configure encoding for test execution due to encoding related test

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>