### PR TITLE
[eclipse/xtext#1280] use newer version of gwt gradle plugin

### DIFF
--- a/org.eclipse.xtend.lib.gwt.test/build.gradle
+++ b/org.eclipse.xtend.lib.gwt.test/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
+		classpath 'org.wisepersist:gwt-gradle-plugin:1.0.6'
 	}
 }
 


### PR DESCRIPTION
[eclipse/xtext#1280] use newer version of gwt gradle plugin

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>