### PR TITLE
Allowed any class in reject without lambda

### DIFF
--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
@@ -195,7 +195,12 @@ public class IterableExtensionsTest extends BaseIterablesIteratorsTest<Iterable<
 		assertEquals(new Pair<Integer, String>(1, "bar"), result.next());
 		assertFalse(result.hasNext());
 	}
-	
+
+	class A {}
+	interface C {}
+	class B extends A implements C {}
+	class D extends A {}
+
 	@Test public void testReject() {
 		List<Integer> nullList = new ArrayList<>();
 		nullList.add(null);
@@ -205,6 +210,12 @@ public class IterableExtensionsTest extends BaseIterablesIteratorsTest<Iterable<
 		
 		List<Integer> integerObjects = newArrayList(1, 2, null, 4);
 		assertEquals(nullList, newArrayList(IterableExtensions.reject(integerObjects, Integer.class)));
+		
+		List<A> bObjects = newArrayList(new B(), new B(), new D());
+		assertEquals(0, IterableExtensions.size(IterableExtensions.reject(bObjects, A.class)));
+		assertEquals(1, IterableExtensions.size(IterableExtensions.reject(bObjects, B.class)));
+		assertEquals(1, IterableExtensions.size(IterableExtensions.reject(bObjects, C.class)));
+		assertEquals(2, IterableExtensions.size(IterableExtensions.reject(bObjects, D.class)));
 		
 		Function1<Integer, Boolean> function = new Function1<Integer, Boolean>() {
 			@Override

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -287,7 +287,7 @@ public class IterableExtensions {
 	 */
 	@GwtIncompatible("Class.isInstance")
 	@Pure
-	public static <T> Iterable<T> reject(Iterable<T> unfiltered, Class<? extends T> type) {
+	public static <T> Iterable<T> reject(Iterable<T> unfiltered, Class<?> type) {
 		return filter(unfiltered, (t) -> !type.isInstance(t));
 	}
 


### PR DESCRIPTION
In #93 I added reject with a `Class` argument.
Sadly I thought the signature was similar to `filter(unfiltered, class)`, where the class type should be the same or a subclass of the iterable's element type (`Class<? extends T> type`).

However this constraint shouldn't be there and it should just allow any class type. See the example in this PR's test.