### PR TITLE
[eclipse/xtext#1249] Use Gradle native BOM management

### DIFF
--- a/2-gradle-build.sh
+++ b/2-gradle-build.sh
@@ -4,7 +4,7 @@ if [ -z "$JENKINS_URL" ]; then
 fi
 
 ./gradlew \
-  clean cleanGenerateXtext build createLocalMavenRepo \
+  clean cleanGenerateXtext build publish \
   -Dmaven.repo.local=$(pwd)/.m2/repository \
   -PcompileXtend=true \
   -PJENKINS_URL=$JENKINS_URL \

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 	repositories.jcenter()
 	dependencies {
 		classpath "org.xtext:xtext-gradle-plugin:$versions.xtext_gradle_plugin"
-		classpath "io.spring.gradle:dependency-management-plugin:$versions.dependency_management_plugin"
 	}
 }
 
@@ -30,17 +29,11 @@ subprojects {
 	}
 	
 	apply plugin: 'java'
-	apply plugin: 'io.spring.dependency-management'
-	dependencyManagement {
-		imports {
-			mavenBom "org.eclipse.xtext:xtext-dev-bom:$project.version"
-		}
-	}
 	if (findProperty('compileXtend') == 'true') {
 		apply plugin: 'org.xtext.xtend'
 	}
 	apply plugin: 'eclipse'
-	apply plugin: 'maven'
+	apply plugin: 'maven-publish'
 	
 	apply from: "${rootDir}/gradle/java-compiler-settings.gradle"
 	apply from: "${rootDir}/gradle/xtend-compiler-settings.gradle"
@@ -48,6 +41,9 @@ subprojects {
 	apply from: "${rootDir}/gradle/eclipse-project-layout.gradle"
 	apply from: "${rootDir}/gradle/manifest-gen.gradle"
 	apply from: "${rootDir}/gradle/validation.gradle"
+	dependencies {
+		compile platform("org.eclipse.xtext:xtext-dev-bom:$project.version")
+	}
 }
 
 task clean(type: Delete) {

--- a/gradle/developers.gradle
+++ b/gradle/developers.gradle
@@ -1,109 +1,106 @@
 /*
  * Information on Xtext developers used in generated pom files for Maven publishing.
  */
-
-project {
-	developers {
-		developer {
-			name = 'Sven Efftinge'
-			email = 'sven.efftinge@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Sebastian Benz'
-		}
-		developer {
-			name = 'Lorenzo Bettini'
-			email = 'lorenzo.bettini@gmail.com'
-			organization = 'DISIA, University Firenze'
-		}
-		developer {
-			name = 'Michael Clay'
-		}
-		developer {
-			name = 'Arne Deutsch'
-			email = 'arne.deutsch@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Christian Dietrich'
-			email = 'christian.dietrich@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Moritz Eysholdt'
-			email = 'moritz.eysholdt@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Dennis Hübner'
-			email = 'dennis.huebner@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Jan Köhnlein'
-			email = 'jan.koehnlein@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Anton Kosyakov'
-			email = 'anton.kosyakov@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Tamas Miklossy'
-			email = 'miklossy@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Stefan Oehme'
-		}
-		developer {
-			name = 'Holger Schill'
-			email = 'holger.schill@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Christian Schneider'
-			email = 'christian.schneider@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Miro Spönemann'
-			email = 'miro.spoenemann@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Karsten Thoms'
-			email = 'karsten.thoms@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Knut Wannheden'
-		}
-		developer {
-			name = 'Sebastian Zarnekow'
-			email = 'sebastian.zarnekow@gmail.com'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Titouan Vervack'
-			email = 'titouan.vervack@sigasi.com'
-			organization = 'Sigasi'
-			organizationUrl = 'https://www.sigasi.com'
-		}
+developers {
+	developer {
+		name = 'Sven Efftinge'
+		email = 'sven.efftinge@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Sebastian Benz'
+	}
+	developer {
+		name = 'Lorenzo Bettini'
+		email = 'lorenzo.bettini@gmail.com'
+		organization = 'DISIA, University Firenze'
+	}
+	developer {
+		name = 'Michael Clay'
+	}
+	developer {
+		name = 'Arne Deutsch'
+		email = 'arne.deutsch@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Christian Dietrich'
+		email = 'christian.dietrich@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Moritz Eysholdt'
+		email = 'moritz.eysholdt@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Dennis Hübner'
+		email = 'dennis.huebner@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Jan Köhnlein'
+		email = 'jan.koehnlein@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Anton Kosyakov'
+		email = 'anton.kosyakov@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Tamas Miklossy'
+		email = 'miklossy@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Stefan Oehme'
+	}
+	developer {
+		name = 'Holger Schill'
+		email = 'holger.schill@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Christian Schneider'
+		email = 'christian.schneider@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Miro Spönemann'
+		email = 'miro.spoenemann@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Karsten Thoms'
+		email = 'karsten.thoms@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Knut Wannheden'
+	}
+	developer {
+		name = 'Sebastian Zarnekow'
+		email = 'sebastian.zarnekow@gmail.com'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Titouan Vervack'
+		email = 'titouan.vervack@sigasi.com'
+		organization = 'Sigasi'
+		organizationUrl = 'https://www.sigasi.com'
 	}
 }

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -4,7 +4,7 @@
 
 // Configuration function for generated POMs
 def configurePom = { pom ->
-	pom.project {
+	pom {
 		if (project.hasProperty('title')) {
 			name = project.title
 			description = project.description
@@ -34,10 +34,46 @@ afterEvaluate {
 		group = 'Upload'
 		description = 'Create or update the local Maven repository'
 		configuration = configurations.archives
-		repositories.mavenDeployer {
-			repository(url: "file:" + file("${rootDir}/build/maven-repository"))
-			configurePom(pom)
+
+		publishing {
+			repositories {
+				maven {
+					url = "file:" + file("${rootDir}/build/maven-repository")
+				}
+				publications {
+					mavenJava(MavenPublication) {
+						from components.java
+						artifact sourcesJar
+						
+						if (! project.name.endsWith("tests")) {
+							artifact javadocJar
+						}
+					
+						pom {
+							if (project.hasProperty('title')) {
+								name = project.title
+								description = project.description
+							}
+							packaging = 'jar'
+							url = 'https://www.eclipse.org/Xtext/'
+							licenses {
+								license {
+									name = 'Eclipse Public License, Version 1.0'
+									url = 'http://www.eclipse.org/legal/epl-v10.html'
+								}
+							}
+							scm {
+								connection = "scm:git:git@github.com:eclipse/${rootProject.name}.git"
+								developerConnection = "scm:git:git@github.com:eclipse/${rootProject.name}.git"
+								url = "git@github.com:eclipse/${rootProject.name}.git"
+							}
+							apply from: "${rootDir}/gradle/developers.gradle", to: pom
+						}
+					}
+				}
+			}
 		}
+
 	}
 	
 }

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -2,30 +2,6 @@
  * Configuration of deployment to Maven repositories.
  */
 
-// Configuration function for generated POMs
-def configurePom = { pom ->
-	pom {
-		if (project.hasProperty('title')) {
-			name = project.title
-			description = project.description
-		}
-		packaging 'jar'
-		url 'https://www.eclipse.org/Xtext/'
-		licenses {
-			license {
-				name 'Eclipse Public License, Version 1.0'
-				url 'http://www.eclipse.org/legal/epl-v10.html'
-			}
-		}
-		scm {
-			connection "scm:git:git@github.com:eclipse/${rootProject.name}.git"
-			developerConnection "scm:git:git@github.com:eclipse/${rootProject.name}.git"
-			url "git@github.com:eclipse/${rootProject.name}.git"
-		}
-	}
-	apply from: "${rootDir}/gradle/developers.gradle", to: pom
-}
-
 // We need to wait until the project's own build file has been executed
 // so we can use the title and description settings for setting up Maven publishing.
 afterEvaluate {
@@ -38,7 +14,7 @@ afterEvaluate {
 		publishing {
 			repositories {
 				maven {
-					url = "file:" + file("${rootDir}/build/maven-repository")
+					url = "file:${rootProject.buildDir}/maven-repository"
 				}
 				publications {
 					mavenJava(MavenPublication) {
@@ -73,7 +49,5 @@ afterEvaluate {
 				}
 			}
 		}
-
 	}
-	
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,6 +8,5 @@ ext.versions = [
 	'xtext_bootstrap': '2.17.0.M1',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '2.0.2',
-	'dependency_management_plugin' : '1.0.6.RELEASE',
 	'gwt': '2.8.2'
 ]

--- a/releng/org.eclipse.xtext.dev-bom/pom.xml
+++ b/releng/org.eclipse.xtext.dev-bom/pom.xml
@@ -61,7 +61,7 @@
 		<asm-version>7.0</asm-version>
 		
 		<error_prone_annotations-version>2.0.15</error_prone_annotations-version>
-		<guava-version>[14.0,21.0]</guava-version>
+		<guava-version>21.0</guava-version>
 		<guice-version>3.0</guice-version>
 		<icu4j-version>52.1</icu4j-version>
 		<javax.annotation-api-version>1.3.2</javax.annotation-api-version>

--- a/releng/org.eclipse.xtext.dev-bom/pom.xml
+++ b/releng/org.eclipse.xtext.dev-bom/pom.xml
@@ -61,7 +61,7 @@
 		<asm-version>7.0</asm-version>
 		
 		<error_prone_annotations-version>2.0.15</error_prone_annotations-version>
-		<guava-version>[14.0,22.0)</guava-version>
+		<guava-version>[14.0,21.0]</guava-version>
 		<guice-version>3.0</guice-version>
 		<icu4j-version>52.1</icu4j-version>
 		<javax.annotation-api-version>1.3.2</javax.annotation-api-version>


### PR DESCRIPTION
- use maven-publish plugin instead of deprecated maven plugin
- remove Spring dependency-management-plugin
- disable javadoc publishing for test projects (they don't produce a
javadoc jar)

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>