### PR TITLE
[eclipse/xtext#1182] added support for java 11 as target

### DIFF
--- a/releng/org.eclipse.xtext.dev-bom/pom.xml
+++ b/releng/org.eclipse.xtext.dev-bom/pom.xml
@@ -75,23 +75,23 @@
 		<!-- Eclipse Platform bundle versions -->
 		<!-- Variable naming scheme:          -->
 		<!--   skip 'org.eclipse' prefix      -->
-		<core.commands-version>3.9.0</core.commands-version>
-		<core.contenttype-version>3.6.0</core.contenttype-version>
-		<core.expressions-version>3.6.0</core.expressions-version>
-		<core.filesystem-version>1.7.0</core.filesystem-version>
-		<core.jobs-version>3.9.3</core.jobs-version>
-		<core.resources-version>3.12.0</core.resources-version>
-		<core.runtime-version>3.13.0</core.runtime-version>
+		<core.commands-version>3.9.200</core.commands-version>
+		<core.contenttype-version>3.7.200</core.contenttype-version>
+		<core.expressions-version>3.6.200</core.expressions-version>
+		<core.filesystem-version>1.7.200</core.filesystem-version>
+		<core.jobs-version>3.10.200</core.jobs-version>
+		<core.resources-version>3.13.200</core.resources-version>
+		<core.runtime-version>3.15.100</core.runtime-version>
 		<emf.common-version>2.12.0</emf.common-version>
 		<emf.ecore-version>2.12.0</emf.ecore-version>
 		<emf.ecore.change-version>2.11.0</emf.ecore.change-version>
 		<emf.codegen-version>2.11.0</emf.codegen-version>
 		<emf.mwe-version>1.3.21.201705291010</emf.mwe-version>
 		<emf.mwe2-version>2.9.1.201705291010</emf.mwe2-version>
-		<equinox.app-version>1.3.400</equinox.app-version>
-		<equinox.common-version>3.9.0</equinox.common-version>
-		<equinox.preferences-version>3.7.0</equinox.preferences-version>
-		<equinox.registry-version>3.7.0</equinox.registry-version>
+		<equinox.app-version>1.4.0</equinox.app-version>
+		<equinox.common-version>3.10.200</equinox.common-version>
+		<equinox.preferences-version>3.7.200</equinox.preferences-version>
+		<equinox.registry-version>3.8.200</equinox.registry-version>
 		<!--
 		When adjusting the `lsp4j` version here, do not forget to do the following: 
 		- Update the version in `IdeProjectDescriptor#pom`.
@@ -101,11 +101,11 @@
 		  `/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF` files.
 		-->
 		<lsp4j-version>0.6.0</lsp4j-version>
-		<jdt.core-version>3.13.102</jdt.core-version>
-		<jdt.compiler.apt-version>1.3.110</jdt.compiler.apt-version>
-		<jdt.compiler.tool-version>1.2.101</jdt.compiler.tool-version>
-		<osgi-version>3.12.100</osgi-version>
-		<text-version>3.6.100</text-version>
+		<jdt.core-version>3.16.0</jdt.core-version>
+		<jdt.compiler.apt-version>1.3.400</jdt.compiler.apt-version>
+		<jdt.compiler.tool-version>1.2.400</jdt.compiler.tool-version>
+		<osgi-version>3.13.200</osgi-version>
+		<text-version>3.8.0</text-version>
 		<xpand-version>2.0.0</xpand-version>
 	</properties>
 	<dependencyManagement>


### PR DESCRIPTION
[eclipse/xtext#1182] added support for java 11 as target
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>