### PR TITLE
[eclipse/xtext#1283] update to mwe 2.10 final

### DIFF
--- a/releng/org.eclipse.xtext.dev-bom/pom.xml
+++ b/releng/org.eclipse.xtext.dev-bom/pom.xml
@@ -87,8 +87,8 @@
 		<emf.ecore-version>2.12.0</emf.ecore-version>
 		<emf.ecore.change-version>2.11.0</emf.ecore.change-version>
 		<emf.codegen-version>2.11.0</emf.codegen-version>
-		<emf.mwe-version>1.4.0.M2</emf.mwe-version>
-		<emf.mwe2-version>2.10.0.M2</emf.mwe2-version>
+		<emf.mwe-version>1.4.0</emf.mwe-version>
+		<emf.mwe2-version>2.10.0</emf.mwe2-version>
 		<equinox.app-version>1.4.0</equinox.app-version>
 		<equinox.common-version>3.10.200</equinox.common-version>
 		<equinox.preferences-version>3.7.200</equinox.preferences-version>


### PR DESCRIPTION
[eclipse/xtext#1283] update to mwe 2.10 final
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>

do not merge before MWE 2.10 is released