### PR TITLE
[eclipse/xtext#1405] bootstrap against 2.17.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@
 version = '2.18.0-SNAPSHOT'
 
 ext.versions = [
-	'xtext_bootstrap': '2.17.0.M2',
+	'xtext_bootstrap': '2.17.0',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '2.0.4',
 	'dependency_management_plugin' : '1.0.6.RELEASE',


### PR DESCRIPTION
[eclipse/xtext#1405] bootstrap against 2.17.0
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>