### PR TITLE
[eclipse/xtext#1424] Change default Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The additional command line argument `-PcompileXtend=true` activates the [Xtend]
 
 ## Continuous Integration
 
-This project is built by the [xtext-lib multi-branch job on Jenkins](https://services.typefox.io/open-source/jenkins/job/xtext-lib/).
+This project is built by the [xtext-lib multi-branch job on Jenkins](https://ci.eclipse.org/xtext/job/xtext-lib/).

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -2,7 +2,7 @@
  * Root project configuration that is reused by subprojects to apply the Xtend compiler.
  */
 if (!hasProperty('JENKINS_URL')) {
-	ext.JENKINS_URL = 'https://services.typefox.io/open-source/jenkins'
+	ext.JENKINS_URL = 'https://ci.eclipse.org/xtext'
 }
 
 // The repositories to query when constructing the Xtend compiler classpath


### PR DESCRIPTION
Use https://ci.eclipse.org/xtext as default Jenkins URL

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>