### PR TITLE
[#131] eliminated compile errors in GWT tests

### DIFF
--- a/org.eclipse.xtend.lib.gwt.test/.classpath
+++ b/org.eclipse.xtend.lib.gwt.test/.classpath
@@ -7,7 +7,12 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="com.gwtplugins.gwt.eclipse.core.GWT_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin/main"/>
 </classpath>

--- a/org.eclipse.xtend.lib.gwt.test/.project
+++ b/org.eclipse.xtend.lib.gwt.test/.project
@@ -21,6 +21,26 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.gwtplugins.gwt.eclipse.core.gwtProjectValidator</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.gwtplugins.gdt.eclipse.core.webAppProjectValidator</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
 			<arguments>
 			</arguments>
@@ -29,6 +49,8 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
+		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.xtend.lib.gwt.test/build.gradle
+++ b/org.eclipse.xtend.lib.gwt.test/build.gradle
@@ -1,13 +1,6 @@
-buildscript {
-	repositories {
-		mavenCentral()
-	}
-	dependencies {
-		classpath 'org.wisepersist:gwt-gradle-plugin:1.0.6'
-	}
+plugins {
+    id "de.esoco.gwt" version "1.0.7"
 }
-
-apply plugin: 'gwt'
 
 group = 'org.eclipse.xtend'
 
@@ -17,20 +10,21 @@ dependencies {
 }
 
 gwt {
-	minHeapSize = "512M";
-	maxHeapSize = "1024M";
 	gwtVersion = versions.gwt
-	modules 'org.eclipse.xtend.lib.test.Test'
-	compiler {
+	module 'org.eclipse.xtend.lib.test.Test'
+	compile {
+		minHeapSize = "512M";
+		maxHeapSize = "1024M";
 		strict = true
-		// enableClosureCompiler = true
-		disableClassMetadata = true
-		disableCastChecking = true
 	}
 }
 
+jar {
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 test {
-	dependsOn compileGwt
+	dependsOn gwtCompile
 }
 
 tasks.withType(Javadoc) {


### PR DESCRIPTION
Replaced GWT Gradle plugin https://github.com/jiakuan/gwt-gradle-plugin with https://github.com/esoco/gwt-gradle-plugin

The jiakuan-plugin has a note for Gradle 5.2+ but no example for actual usage.
The esoco-plugin seems to be maintained and has an actual documentation for usage.
An alternative could be https://github.com/ascendtech/gwt-gradle but this project is just one year old.
An secound alternative could be https://github.com/big-guy/gwt-gradle-plugin. There are few commits for mantaining new gradle versions, but no up to date releases for this.