### PR TITLE
[releng] Fix minor issues with JIRO

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(numToKeepStr:'15'))
+    timeout(time: 30, unit: 'MINUTES')
   }
 
   tools { 
@@ -27,7 +28,6 @@ pipeline {
     stage('Gradle Build') {
       steps {
         sh './2-gradle-build.sh'
-        step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/test/*.xml'])
       }
     }
     
@@ -39,6 +39,9 @@ pipeline {
   }
 
   post {
+    always {
+      junit testResults: '**/build/test-results/test/*.xml'
+    }
     success {
       archiveArtifacts artifacts: 'build/**'
     }


### PR DESCRIPTION
Replaces #192, since changes to Jenkinsfile by contributors are untrusted and not executed in PR builds. Adopted changes from #192.

- [eclipse/xtext#1431] Add resource limits to fix OOM failures
- [eclipse/xtext#1463] Configure job timeouts
- [eclipse/xtext#1465] Use declarative JUnit step
- Add JIRO as known environment qualifier for build notification message

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>
Also-by: Nico Prediger <mail@nicoprediger.de>