### PR TITLE
update to guava 27.1

### DIFF
--- a/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib.gwt/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 2.19.0.qualifier
 Export-Package: org.eclipse.xtend2.lib,
  org.eclipse.xtext.xbase.lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: com.google.guava;bundle-version="[21.0.0,22.0.0)"
+Require-Bundle: com.google.guava;bundle-version="[27.1.0,28.0.0)"
 Bundle-Vendor: %Vendor-Name
 Automatic-Module-Name: org.eclipse.xtext.xbase.lib.gwt

--- a/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.lib/META-INF/MANIFEST.MF
@@ -8,6 +8,6 @@ Export-Package: org.eclipse.xtend2.lib;version="2.19.0",
  org.eclipse.xtext.xbase.lib;version="2.19.0",
  org.eclipse.xtext.xbase.lib.internal;x-internal:="true",
  org.eclipse.xtext.xbase.lib.util;version="2.19.0"
-Require-Bundle: com.google.guava;bundle-version="[21.0.0,22.0.0)";visibility:=reexport
+Require-Bundle: com.google.guava;bundle-version="[27.1.0,28.0.0)";visibility:=reexport
 Bundle-Vendor: Eclipse Xtext
 Automatic-Module-Name: org.eclipse.xtext.xbase.lib

--- a/releng/org.eclipse.xtext.dev-bom/pom.xml
+++ b/releng/org.eclipse.xtext.dev-bom/pom.xml
@@ -65,8 +65,8 @@
 		<asm-version>7.1</asm-version>
 		<classgraph-version>4.8.35</classgraph-version>
 		
-		<error_prone_annotations-version>2.0.15</error_prone_annotations-version>
-		<guava-version>21.0</guava-version>
+		<error_prone_annotations-version>2.2.0</error_prone_annotations-version>
+		<guava-version>27.1-jre</guava-version>
 		<guice-version>3.0</guice-version>
 		<icu4j-version>52.1</icu4j-version>
 		<javax.annotation-api-version>1.3.2</javax.annotation-api-version>


### PR DESCRIPTION
Fixes eclipse/xtext#1398 and eclipse/xtext-lib#111

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>