### PR TITLE
[eclipse/xtext#1431] Enhancing container support

### DIFF
--- a/2-gradle-build.sh
+++ b/2-gradle-build.sh
@@ -3,6 +3,10 @@ if [ -z "$JENKINS_URL" ]; then
   JENKINS_URL=https://ci.eclipse.org/xtext/
 fi
 
+if [ -f "/.dockerenv" ]; then
+  export GRADLE_OPTS="-Dorg.gradle.daemon=false"
+fi
+
 ./gradlew \
   clean cleanGenerateXtext build createLocalMavenRepo \
   -Dmaven.repo.local=$(pwd)/.m2/repository \
@@ -10,4 +14,5 @@ fi
   -PJENKINS_URL=$JENKINS_URL \
   -PignoreTestFailures=true \
   --refresh-dependencies \
-  --continue
+  --continue \
+  $@

--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -20,10 +20,8 @@ spec:
     resources:
       limits:
         memory: "2Gi"
-        cpu: "1"
       requests:
         memory: "2Gi"
-        cpu: "1"
     volumeMounts:
     - name: settings-xml
       mountPath: /home/jenkins/.m2/settings.xml
@@ -74,8 +72,6 @@ spec:
 
     stage('Build Xtext BOM') {
       steps {
-        dir('.m2/repository/org/eclipse/xtext') { deleteDir() }
-        dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
         sh './1-install-bom.sh'
       }
     }

--- a/org.eclipse.xtend.lib.gwt.test/build.gradle
+++ b/org.eclipse.xtend.lib.gwt.test/build.gradle
@@ -13,8 +13,6 @@ gwt {
 	gwtVersion = versions.gwt
 	module 'org.eclipse.xtend.lib.test.Test'
 	compile {
-		minHeapSize = "512M";
-		maxHeapSize = "1024M";
 		strict = true
 	}
 }


### PR DESCRIPTION
- Disable Gradle daemon, since a new container for each build is
spawned and the daemon can't be reused anyway.

- Remove CPU resource constraint, since default is sufficient.

- Remove memory options for GWT compile. Works also without and
potentially causes problems in memory limited containers, esp. when
minHeapSize can't be assured.

- Remove cleanup of Maven repo: Not necessary when running in a
container. The Maven repo is always empty at beginning.

- Remove memory settings for GWT compile task: Potentially causes
problems in memory limited container

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>