### PR TITLE
[eclipse/xtext#1279] use orbit simrel alias directly

### DIFF
--- a/releng/releng-target/xtext-lib.target.target
+++ b/releng/releng-target/xtext-lib.target.target
@@ -2,9 +2,9 @@
 <?pde version="3.8"?>
 <target name="org.eclipse.xtext.helios.target" sequenceNumber="0">
 	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/oxygen/201804111000"/>
-			<unit id="com.google.guava" version="0.0.0"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
+			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>


### PR DESCRIPTION
[eclipse/xtext#1279] use orbit simrel alias directly
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>