### PR TITLE
[eclipse/xtext-xtend#877] added 'contains' to array/iterable/iterator

### DIFF
--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsBooleanTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsBooleanTest.xtend
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import java.util.Objects
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsBooleanTest {
+
+	var boolean[] data
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def boolean[] createData() {
+		val boolean[] array = newBooleanArrayOfSize(3)
+		array.set(0, true)
+		array.set(1, false)
+		array.set(2, true)
+		return array
+	}
+
+	@Test
+	def void testSetGet__boolean() {
+		assertTrue(data.get(0))
+		assertFalse(data.get(1))
+		assertTrue(data.get(2))
+	}
+
+	@Test
+	def void testClone__boolean() {
+		val clonedData = data.clone();
+
+		assertTrue(clonedData.get(0))
+		assertFalse(clonedData.get(1))
+		assertTrue(clonedData.get(2))
+	}
+
+	@Test
+	def void testLength__boolean() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__boolean() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__boolean() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, true)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test
+	def void testContains__boolean() {
+		assertTrue(data.contains(true))
+		assertTrue(data.contains(false))
+		
+		val onlyFalse = newBooleanArrayOfSize(2) => [
+			set(0, false)
+			set(1, false)
+		]
+
+		assertFalse(onlyFalse.contains(true))
+		assertTrue(onlyFalse.contains(false))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsByteTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsByteTest.xtend
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+import java.util.Objects
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsByteTest {
+
+	var byte[] data
+
+	val byte _10 = 10 as byte
+	val byte _20 = 20 as byte
+	val byte _30 = 30 as byte
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def byte[] createData() {
+		val byte[] array = newByteArrayOfSize(3)
+		array.set(0, _10)
+		array.set(1, _20)
+		array.set(2, _30)
+		return array
+	}
+
+	@Test
+	def void testSetGet__byte() {
+		assertEquals(_10, data.get(0))
+		assertEquals(_20, data.get(1))
+		assertEquals(_30, data.get(2))
+	}
+
+	@Test
+	def void testClone__byte() {
+		val clonedData = data.clone();
+
+		assertEquals(_10, clonedData.get(0))
+		assertEquals(_20, clonedData.get(1))
+		assertEquals(_30, clonedData.get(2))
+	}
+
+	@Test
+	def void testLength__byte() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__byte() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__byte() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, 0 as byte)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test 
+	def void testContains__byte() {
+		assertTrue(data.contains(10 as byte))
+		assertTrue(data.contains(20 as byte)) 
+		assertTrue(data.contains(30 as byte))
+		
+		assertFalse(data.contains(40 as byte))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsCharTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsCharTest.xtend
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+import java.util.Objects
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsCharTest {
+
+	var char[] data
+	
+	val char a = 'a'
+	val char b = 'b'
+	val char c = 'c'
+	
+	val char x = 'x'
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def char[] createData() {
+		val char[] array = newCharArrayOfSize(3)
+		array.set(0, a) 
+		array.set(1, b)
+		array.set(2, c)
+		return array
+	}
+
+	@Test
+	def void testSetGet__char() {
+		assertEquals(a, data.get(0))
+		assertEquals(b, data.get(1))
+		assertEquals(c, data.get(2))
+	}
+
+	@Test
+	def void testClone__char() {
+		val clonedData = data.clone();
+
+		assertEquals(a, clonedData.get(0))
+		assertEquals(b, clonedData.get(1))
+		assertEquals(c, clonedData.get(2))
+	}
+
+	@Test
+	def void testLength__char() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__char() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__char() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, a)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test 
+	def void testContains__char() {
+		assertTrue(data.contains(a))
+		assertTrue(data.contains(b))
+		assertTrue(data.contains(c))
+		
+		assertFalse(data.contains(x))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsDoubleTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsDoubleTest.xtend
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import java.util.Objects
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsDoubleTest {
+
+	var double[] data
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def double[] createData() {
+		val double[] array = newDoubleArrayOfSize(3)
+		array.set(0, 10.0)
+		array.set(1, 20.0)
+		array.set(2, 30.0)
+		return array
+	}
+
+	@Test
+	def void testSetGet__double() {
+		assertEquals(10.0, data.get(0), 0.001)
+		assertEquals(20.0, data.get(1), 0.001)
+		assertEquals(30.0, data.get(2), 0.001)
+	}
+
+	@Test
+	def void testClone__double() {
+		val clonedData = data.clone();
+
+		assertEquals(10.0, clonedData.get(0), 0.001)
+		assertEquals(20.0, clonedData.get(1), 0.001)
+		assertEquals(30.0, clonedData.get(2), 0.001)
+	}
+
+	@Test
+	def void testLength__double() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__double() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__double() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, 0.0)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test
+	def void testContains__double() {
+		assertTrue(data.contains(10.0))
+		assertTrue(data.contains(20.0))
+		assertTrue(data.contains(30.0))
+		
+		assertFalse(data.contains(40.0))
+	}
+	
+	@Test
+	def void testContains__float_NaN() {
+		val double[] nanData = #[1.0, Double.NaN]
+		
+		assertTrue(nanData.contains(Double.NaN))
+		assertTrue(nanData.contains(0f / 0f))
+		assertTrue(nanData.contains(Math.log(-1)))
+		
+		assertFalse(nanData.contains(Double.NEGATIVE_INFINITY))
+		assertFalse(nanData.contains(Double.POSITIVE_INFINITY))
+	}
+	
+	@Test
+	def void testContains__double_posInfinity() {
+		val double[] nanData = #[1.0f, Double.POSITIVE_INFINITY]
+		
+		assertTrue(nanData.contains(Double.POSITIVE_INFINITY))
+		assertTrue(nanData.contains(Double.POSITIVE_INFINITY + 7.2f))
+		
+		assertFalse(nanData.contains(Double.NaN))
+		assertFalse(nanData.contains(0f / 0f))
+		assertFalse(nanData.contains(Math.log(-1)))
+		assertFalse(nanData.contains(Double.NEGATIVE_INFINITY))
+	}
+
+	@Test
+	def void testContains__double_negInfinity() {
+		val double[] nanData = #[1.0f, Double.NEGATIVE_INFINITY]
+		
+		assertTrue(nanData.contains(Double.NEGATIVE_INFINITY))
+		assertTrue(nanData.contains(Double.NEGATIVE_INFINITY + 7.2f))
+		
+		assertFalse(nanData.contains(Double.NaN))
+		assertFalse(nanData.contains(0f / 0f))
+		assertFalse(nanData.contains(Math.log(-1)))
+		assertFalse(nanData.contains(Double.POSITIVE_INFINITY))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsFloatTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsFloatTest.xtend
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import java.util.Objects
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsFloatTest {
+
+	var float[] data
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def float[] createData() {
+		val float[] array = newFloatArrayOfSize(3)
+		array.set(0, 10.0f)
+		array.set(1, 20.0f)
+		array.set(2, 30.0f)
+		return array
+	}
+
+	@Test
+	def void testSetGet__float() {
+		assertEquals(10.0f, data.get(0), 0.001f)
+		assertEquals(20.0f, data.get(1), 0.001f)
+		assertEquals(30.0f, data.get(2), 0.001f)
+	}
+
+	@Test
+	def void testClone__float() {
+		val clonedData = data.clone();
+
+		assertEquals(10.0f, clonedData.get(0), 0.001f)
+		assertEquals(20.0f, clonedData.get(1), 0.001f)
+		assertEquals(30.0f, clonedData.get(2), 0.001f)
+	}
+
+	@Test
+	def void testLength__float() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__float() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__float() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, 0.0f)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test 
+	def void testContains__float() {
+		assertTrue(data.contains(10.0f))
+		assertTrue(data.contains(20.0f))
+		assertTrue(data.contains(30.0f))
+		
+		assertFalse(data.contains(40.0f))
+	}
+	
+	@Test
+	def void testContains__float_NaN() {
+		val float[] nanData = #[1.0f, Float.NaN]
+		
+		assertTrue(nanData.contains(Float.NaN))
+		assertTrue(nanData.contains(0f / 0f))
+		assertTrue(nanData.contains(Math.log(-1) as float))
+		
+		assertFalse(nanData.contains(Float.NEGATIVE_INFINITY))
+		assertFalse(nanData.contains(Float.POSITIVE_INFINITY))
+	}
+	
+	@Test
+	def void testContains__float_posInfinity() {
+		val float[] nanData = #[1.0f, Float.POSITIVE_INFINITY]
+		
+		assertTrue(nanData.contains(Float.POSITIVE_INFINITY))
+		assertTrue(nanData.contains(Float.POSITIVE_INFINITY + 7.2f))
+		
+		assertFalse(nanData.contains(Float.NaN))
+		assertFalse(nanData.contains(0f / 0f))
+		assertFalse(nanData.contains(Math.log(-1) as float))
+		assertFalse(nanData.contains(Float.NEGATIVE_INFINITY))
+	}
+
+	@Test
+	def void testContains__float_negInfinity() {
+		val float[] nanData = #[1.0f, Float.NEGATIVE_INFINITY]
+		
+		assertTrue(nanData.contains(Float.NEGATIVE_INFINITY))
+		assertTrue(nanData.contains(Float.NEGATIVE_INFINITY + 7.2f))
+		
+		assertFalse(nanData.contains(Float.NaN))
+		assertFalse(nanData.contains(0f / 0f))
+		assertFalse(nanData.contains(Math.log(-1) as float))
+		assertFalse(nanData.contains(Float.POSITIVE_INFINITY))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsIntTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsIntTest.xtend
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+import java.util.Objects
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsIntTest {
+
+	var int[] data
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def int[] createData() {
+		val int[] array = newIntArrayOfSize(3)
+		array.set(0, 10)
+		array.set(1, 20)
+		array.set(2, 30)
+		return array
+	}
+
+	@Test
+	def void testSetGet__int() {
+		assertEquals(10, data.get(0))
+		assertEquals(20, data.get(1))
+		assertEquals(30, data.get(2))
+	}
+
+	@Test
+	def void testClone__int() {
+		val clonedData = data.clone();
+
+		assertEquals(10, clonedData.get(0))
+		assertEquals(20, clonedData.get(1))
+		assertEquals(30, clonedData.get(2))
+	}
+
+	@Test
+	def void testLength__int() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__int() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__int() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, 0)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test 
+	def void testContains__int() {
+		assertTrue(data.contains(10))
+		assertTrue(data.contains(20))
+		assertTrue(data.contains(30))
+		
+		assertFalse(data.contains(40))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsLongTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsLongTest.xtend
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+import java.util.Objects
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsLongTest {
+
+	var long[] data
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def long[] createData() {
+		val long[] array = newLongArrayOfSize(3)
+		array.set(0, 10l)
+		array.set(1, 20l)
+		array.set(2, 30l)
+		return array
+	}
+
+	@Test
+	def void testSetGet__long() {
+		assertEquals(10l, data.get(0))
+		assertEquals(20l, data.get(1))
+		assertEquals(30l, data.get(2))
+	}
+
+	@Test
+	def void testClone__long() {
+		val clonedData = data.clone();
+
+		assertEquals(10l, clonedData.get(0))
+		assertEquals(20l, clonedData.get(1))
+		assertEquals(30l, clonedData.get(2))
+	}
+
+	@Test
+	def void testLength__long() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__long() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__long() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, 0l)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test 
+	def void testContains__long() {
+		assertTrue(data.contains(10l))
+		assertTrue(data.contains(20l))
+		assertTrue(data.contains(30l))
+		
+		assertFalse(data.contains(40l))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsObjectTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsObjectTest.xtend
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import java.util.Objects
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsObjectTest {
+
+	var Object[] data
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def Object[] createData() {
+		val Object[] array = newArrayOfSize(3)
+		array.set(0, Integer.valueOf(0))
+		array.set(1, Integer.valueOf(1))
+		array.set(2, null)
+		return array
+	}
+
+	@Test
+	def void testSetGet__Object() {
+		assertSame(Integer.valueOf(0), data.get(0))
+		assertSame(Integer.valueOf(1), data.get(1))
+		assertNull(null, data.get(2))
+	}
+
+	@Test
+	def void testClone__Object() {
+		val clonedData = data.clone();
+
+		assertSame(Integer.valueOf(0), clonedData.get(0))
+		assertSame(Integer.valueOf(1), clonedData.get(1))
+		assertNull(null, data.get(2))
+	}
+
+	@Test
+	def void testLength__Object() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__Object() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__Object() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, "Hello World")]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test
+	def void testContains__Object() {
+		assertTrue(data.contains(Integer.valueOf(0)))
+		assertTrue(data.contains(Integer.valueOf(1)))
+		assertTrue(data.contains(null))
+
+		assertFalse(data.contains(Integer.valueOf(3)))
+		assertFalse(data.contains(Integer.valueOf(4)))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsShortTest.xtend
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsShortTest.xtend
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.tests.lib
+
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+import java.util.Objects
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+class ArrayExtensionsShortTest {
+
+	var short[] data
+
+	val short _10 = 10 as short
+	val short _20 = 20 as short
+	val short _30 = 30 as short
+
+	@Before
+	def void init() {
+		data = createData()
+	}
+
+	private def short[] createData() {
+		val short[] array = newShortArrayOfSize(3)
+		array.set(0, _10)
+		array.set(1, _20)
+		array.set(2, _30)
+		return array
+	}
+
+	@Test
+	def void testSetGet__short() {
+		assertEquals(_10, data.get(0))
+		assertEquals(_20, data.get(1))
+		assertEquals(_30, data.get(2))
+	}
+
+	@Test
+	def void testClone__short() {
+		val clonedData = data.clone();
+
+		assertEquals(_10, clonedData.get(0))
+		assertEquals(_20, clonedData.get(1))
+		assertEquals(_30, clonedData.get(2))
+	}
+
+	@Test
+	def void testLength__short() {
+		assertEquals(3, data.length)
+	}
+
+	@Test
+	def void testHashCode__short() {
+		assertEquals(Objects.hashCode(data), data.hashCode)
+	}
+
+	@Test
+	def void testEquals__short() {
+		assertTrue(data.equals(data))
+
+		assertFalse(data.equals(createData()))
+		assertFalse(data.equals(newArrayOfSize(3)))
+		assertFalse(data.equals(null))
+
+		val newData = createData() => [it.set(1, 0 as short)]
+		assertFalse(data.equals(newData))
+	}
+
+	@Test 
+	def void testContains__short() {
+		assertTrue(data.contains(10 as short))
+		assertTrue(data.contains(20 as short))
+		assertTrue(data.contains(30 as short))
+		
+		assertFalse(data.contains(40 as short))
+	}
+
+}

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.xtext.xbase.lib.Functions;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
@@ -400,5 +401,17 @@ public class IteratorExtensionsTest extends BaseIterablesIteratorsTest<Iterator<
 			}
 		};
 		assertEquals(newArrayList("Hello", "foo", "Hello", "bar"), newArrayList(IteratorExtensions.flatMap(list.iterator(), function)));
+	}
+	
+	@Test public void testContains() {
+		ArrayList<String> list = newArrayList("element1", "element2", "element3", null);
+		
+		assertTrue(IteratorExtensions.contains(list.iterator(), "element3"));
+		assertTrue(IteratorExtensions.contains(list.iterator(), new String("element3")));
+		
+		assertTrue(IteratorExtensions.contains(list.iterator(), null));
+		
+		assertFalse(IteratorExtensions.contains(list.iterator(), "element4"));
+		assertFalse(IteratorExtensions.contains(list.iterator(), new String("element4")));
 	}
 }

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsBooleanTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsBooleanTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsBooleanTest {
+  private boolean[] data;
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private boolean[] createData() {
+    final boolean[] array = new boolean[3];
+    array[0] = true;
+    array[1] = false;
+    array[2] = true;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__boolean() {
+    Assert.assertTrue(this.data[0]);
+    Assert.assertFalse(this.data[1]);
+    Assert.assertTrue(this.data[2]);
+  }
+  
+  @Test
+  public void testClone__boolean() {
+    final boolean[] clonedData = this.data.clone();
+    Assert.assertTrue(clonedData[0]);
+    Assert.assertFalse(clonedData[1]);
+    Assert.assertTrue(clonedData[2]);
+  }
+  
+  @Test
+  public void testLength__boolean() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__boolean() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__boolean() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    boolean[] _createData = this.createData();
+    final Procedure1<boolean[]> _function = (boolean[] it) -> {
+      it[1] = true;
+    };
+    final boolean[] newData = ObjectExtensions.<boolean[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__boolean() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, true));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, false));
+    boolean[] _newBooleanArrayOfSize = new boolean[2];
+    final Procedure1<boolean[]> _function = (boolean[] it) -> {
+      it[0] = false;
+      it[1] = false;
+    };
+    final boolean[] onlyFalse = ObjectExtensions.<boolean[]>operator_doubleArrow(_newBooleanArrayOfSize, _function);
+    Assert.assertFalse(ArrayExtensions.contains(onlyFalse, true));
+    Assert.assertTrue(ArrayExtensions.contains(onlyFalse, false));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsByteTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsByteTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsByteTest {
+  private byte[] data;
+  
+  private final byte _10 = ((byte) 10);
+  
+  private final byte _20 = ((byte) 20);
+  
+  private final byte _30 = ((byte) 30);
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private byte[] createData() {
+    final byte[] array = new byte[3];
+    array[0] = this._10;
+    array[1] = this._20;
+    array[2] = this._30;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__byte() {
+    Assert.assertEquals(this._10, this.data[0]);
+    Assert.assertEquals(this._20, this.data[1]);
+    Assert.assertEquals(this._30, this.data[2]);
+  }
+  
+  @Test
+  public void testClone__byte() {
+    final byte[] clonedData = this.data.clone();
+    Assert.assertEquals(this._10, clonedData[0]);
+    Assert.assertEquals(this._20, clonedData[1]);
+    Assert.assertEquals(this._30, clonedData[2]);
+  }
+  
+  @Test
+  public void testLength__byte() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__byte() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__byte() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    byte[] _createData = this.createData();
+    final Procedure1<byte[]> _function = (byte[] it) -> {
+      it[1] = ((byte) 0);
+    };
+    final byte[] newData = ObjectExtensions.<byte[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__byte() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, ((byte) 10)));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, ((byte) 20)));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, ((byte) 30)));
+    Assert.assertFalse(ArrayExtensions.contains(this.data, ((byte) 40)));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsCharTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsCharTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsCharTest {
+  private char[] data;
+  
+  private final char a = 'a';
+  
+  private final char b = 'b';
+  
+  private final char c = 'c';
+  
+  private final char x = 'x';
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private char[] createData() {
+    final char[] array = new char[3];
+    array[0] = this.a;
+    array[1] = this.b;
+    array[2] = this.c;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__char() {
+    Assert.assertEquals(this.a, this.data[0]);
+    Assert.assertEquals(this.b, this.data[1]);
+    Assert.assertEquals(this.c, this.data[2]);
+  }
+  
+  @Test
+  public void testClone__char() {
+    final char[] clonedData = this.data.clone();
+    Assert.assertEquals(this.a, clonedData[0]);
+    Assert.assertEquals(this.b, clonedData[1]);
+    Assert.assertEquals(this.c, clonedData[2]);
+  }
+  
+  @Test
+  public void testLength__char() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__char() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__char() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    char[] _createData = this.createData();
+    final Procedure1<char[]> _function = (char[] it) -> {
+      it[1] = this.a;
+    };
+    final char[] newData = ObjectExtensions.<char[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__char() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, this.a));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, this.b));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, this.c));
+    Assert.assertFalse(ArrayExtensions.contains(this.data, this.x));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsDoubleTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsDoubleTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsDoubleTest {
+  private double[] data;
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private double[] createData() {
+    final double[] array = new double[3];
+    array[0] = 10.0;
+    array[1] = 20.0;
+    array[2] = 30.0;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__double() {
+    Assert.assertEquals(10.0, this.data[0], 0.001);
+    Assert.assertEquals(20.0, this.data[1], 0.001);
+    Assert.assertEquals(30.0, this.data[2], 0.001);
+  }
+  
+  @Test
+  public void testClone__double() {
+    final double[] clonedData = this.data.clone();
+    Assert.assertEquals(10.0, clonedData[0], 0.001);
+    Assert.assertEquals(20.0, clonedData[1], 0.001);
+    Assert.assertEquals(30.0, clonedData[2], 0.001);
+  }
+  
+  @Test
+  public void testLength__double() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__double() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__double() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    double[] _createData = this.createData();
+    final Procedure1<double[]> _function = (double[] it) -> {
+      it[1] = 0.0;
+    };
+    final double[] newData = ObjectExtensions.<double[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__double() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 10.0));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 20.0));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 30.0));
+    Assert.assertFalse(ArrayExtensions.contains(this.data, 40.0));
+  }
+  
+  @Test
+  public void testContains__float_NaN() {
+    final double[] nanData = { 1.0, Double.NaN };
+    Assert.assertTrue(ArrayExtensions.contains(nanData, Double.NaN));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, (0f / 0f)));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, Math.log((-1))));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Double.NEGATIVE_INFINITY));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Double.POSITIVE_INFINITY));
+  }
+  
+  @Test
+  public void testContains__double_posInfinity() {
+    final double[] nanData = { 1.0f, Double.POSITIVE_INFINITY };
+    Assert.assertTrue(ArrayExtensions.contains(nanData, Double.POSITIVE_INFINITY));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, (Double.POSITIVE_INFINITY + 7.2f)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Double.NaN));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, (0f / 0f)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Math.log((-1))));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Double.NEGATIVE_INFINITY));
+  }
+  
+  @Test
+  public void testContains__double_negInfinity() {
+    final double[] nanData = { 1.0f, Double.NEGATIVE_INFINITY };
+    Assert.assertTrue(ArrayExtensions.contains(nanData, Double.NEGATIVE_INFINITY));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, (Double.NEGATIVE_INFINITY + 7.2f)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Double.NaN));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, (0f / 0f)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Math.log((-1))));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Double.POSITIVE_INFINITY));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsFloatTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsFloatTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsFloatTest {
+  private float[] data;
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private float[] createData() {
+    final float[] array = new float[3];
+    array[0] = 10.0f;
+    array[1] = 20.0f;
+    array[2] = 30.0f;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__float() {
+    Assert.assertEquals(10.0f, this.data[0], 0.001f);
+    Assert.assertEquals(20.0f, this.data[1], 0.001f);
+    Assert.assertEquals(30.0f, this.data[2], 0.001f);
+  }
+  
+  @Test
+  public void testClone__float() {
+    final float[] clonedData = this.data.clone();
+    Assert.assertEquals(10.0f, clonedData[0], 0.001f);
+    Assert.assertEquals(20.0f, clonedData[1], 0.001f);
+    Assert.assertEquals(30.0f, clonedData[2], 0.001f);
+  }
+  
+  @Test
+  public void testLength__float() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__float() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__float() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    float[] _createData = this.createData();
+    final Procedure1<float[]> _function = (float[] it) -> {
+      it[1] = 0.0f;
+    };
+    final float[] newData = ObjectExtensions.<float[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__float() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 10.0f));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 20.0f));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 30.0f));
+    Assert.assertFalse(ArrayExtensions.contains(this.data, 40.0f));
+  }
+  
+  @Test
+  public void testContains__float_NaN() {
+    final float[] nanData = { 1.0f, Float.NaN };
+    Assert.assertTrue(ArrayExtensions.contains(nanData, Float.NaN));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, (0f / 0f)));
+    double _log = Math.log((-1));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, ((float) _log)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Float.NEGATIVE_INFINITY));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Float.POSITIVE_INFINITY));
+  }
+  
+  @Test
+  public void testContains__float_posInfinity() {
+    final float[] nanData = { 1.0f, Float.POSITIVE_INFINITY };
+    Assert.assertTrue(ArrayExtensions.contains(nanData, Float.POSITIVE_INFINITY));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, (Float.POSITIVE_INFINITY + 7.2f)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Float.NaN));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, (0f / 0f)));
+    double _log = Math.log((-1));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, ((float) _log)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Float.NEGATIVE_INFINITY));
+  }
+  
+  @Test
+  public void testContains__float_negInfinity() {
+    final float[] nanData = { 1.0f, Float.NEGATIVE_INFINITY };
+    Assert.assertTrue(ArrayExtensions.contains(nanData, Float.NEGATIVE_INFINITY));
+    Assert.assertTrue(ArrayExtensions.contains(nanData, (Float.NEGATIVE_INFINITY + 7.2f)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Float.NaN));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, (0f / 0f)));
+    double _log = Math.log((-1));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, ((float) _log)));
+    Assert.assertFalse(ArrayExtensions.contains(nanData, Float.POSITIVE_INFINITY));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsIntTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsIntTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsIntTest {
+  private int[] data;
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private int[] createData() {
+    final int[] array = new int[3];
+    array[0] = 10;
+    array[1] = 20;
+    array[2] = 30;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__int() {
+    Assert.assertEquals(10, this.data[0]);
+    Assert.assertEquals(20, this.data[1]);
+    Assert.assertEquals(30, this.data[2]);
+  }
+  
+  @Test
+  public void testClone__int() {
+    final int[] clonedData = this.data.clone();
+    Assert.assertEquals(10, clonedData[0]);
+    Assert.assertEquals(20, clonedData[1]);
+    Assert.assertEquals(30, clonedData[2]);
+  }
+  
+  @Test
+  public void testLength__int() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__int() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__int() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    int[] _createData = this.createData();
+    final Procedure1<int[]> _function = (int[] it) -> {
+      it[1] = 0;
+    };
+    final int[] newData = ObjectExtensions.<int[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__int() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 10));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 20));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 30));
+    Assert.assertFalse(ArrayExtensions.contains(this.data, 40));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsLongTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsLongTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsLongTest {
+  private long[] data;
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private long[] createData() {
+    final long[] array = new long[3];
+    array[0] = 10l;
+    array[1] = 20l;
+    array[2] = 30l;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__long() {
+    Assert.assertEquals(10l, this.data[0]);
+    Assert.assertEquals(20l, this.data[1]);
+    Assert.assertEquals(30l, this.data[2]);
+  }
+  
+  @Test
+  public void testClone__long() {
+    final long[] clonedData = this.data.clone();
+    Assert.assertEquals(10l, clonedData[0]);
+    Assert.assertEquals(20l, clonedData[1]);
+    Assert.assertEquals(30l, clonedData[2]);
+  }
+  
+  @Test
+  public void testLength__long() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__long() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__long() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    long[] _createData = this.createData();
+    final Procedure1<long[]> _function = (long[] it) -> {
+      it[1] = 0l;
+    };
+    final long[] newData = ObjectExtensions.<long[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__long() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 10l));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 20l));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, 30l));
+    Assert.assertFalse(ArrayExtensions.contains(this.data, 40l));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsObjectTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsObjectTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsObjectTest {
+  private Object[] data;
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private Object[] createData() {
+    final Object[] array = new Object[3];
+    array[0] = Integer.valueOf(0);
+    array[1] = Integer.valueOf(1);
+    array[2] = null;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__Object() {
+    Assert.assertSame(Integer.valueOf(0), this.data[0]);
+    Assert.assertSame(Integer.valueOf(1), this.data[1]);
+    Assert.assertNull(null, this.data[2]);
+  }
+  
+  @Test
+  public void testClone__Object() {
+    final Object[] clonedData = this.data.clone();
+    Assert.assertSame(Integer.valueOf(0), clonedData[0]);
+    Assert.assertSame(Integer.valueOf(1), clonedData[1]);
+    Assert.assertNull(null, this.data[2]);
+  }
+  
+  @Test
+  public void testLength__Object() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__Object() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__Object() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    Object[] _createData = this.createData();
+    final Procedure1<Object[]> _function = (Object[] it) -> {
+      it[1] = "Hello World";
+    };
+    final Object[] newData = ObjectExtensions.<Object[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__Object() {
+    Assert.assertTrue(ArrayExtensions.<Object>contains(this.data, Integer.valueOf(0)));
+    Assert.assertTrue(ArrayExtensions.<Object>contains(this.data, Integer.valueOf(1)));
+    Assert.assertTrue(ArrayExtensions.<Object>contains(this.data, null));
+    Assert.assertFalse(ArrayExtensions.<Object>contains(this.data, Integer.valueOf(3)));
+    Assert.assertFalse(ArrayExtensions.<Object>contains(this.data, Integer.valueOf(4)));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsShortTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/xtend-gen/org/eclipse/xtext/xbase/tests/lib/ArrayExtensionsShortTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xbase.tests.lib;
+
+import java.util.Objects;
+import org.eclipse.xtext.xbase.lib.ArrayExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Mathias Rieder - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ArrayExtensionsShortTest {
+  private short[] data;
+  
+  private final short _10 = ((short) 10);
+  
+  private final short _20 = ((short) 20);
+  
+  private final short _30 = ((short) 30);
+  
+  @Before
+  public void init() {
+    this.data = this.createData();
+  }
+  
+  private short[] createData() {
+    final short[] array = new short[3];
+    array[0] = this._10;
+    array[1] = this._20;
+    array[2] = this._30;
+    return array;
+  }
+  
+  @Test
+  public void testSetGet__short() {
+    Assert.assertEquals(this._10, this.data[0]);
+    Assert.assertEquals(this._20, this.data[1]);
+    Assert.assertEquals(this._30, this.data[2]);
+  }
+  
+  @Test
+  public void testClone__short() {
+    final short[] clonedData = this.data.clone();
+    Assert.assertEquals(this._10, clonedData[0]);
+    Assert.assertEquals(this._20, clonedData[1]);
+    Assert.assertEquals(this._30, clonedData[2]);
+  }
+  
+  @Test
+  public void testLength__short() {
+    Assert.assertEquals(3, this.data.length);
+  }
+  
+  @Test
+  public void testHashCode__short() {
+    Assert.assertEquals(Objects.hashCode(this.data), this.data.hashCode());
+  }
+  
+  @Test
+  public void testEquals__short() {
+    Assert.assertTrue(this.data.equals(this.data));
+    Assert.assertFalse(this.data.equals(this.createData()));
+    Assert.assertFalse(this.data.equals(new Object[3]));
+    Assert.assertFalse(this.data.equals(null));
+    short[] _createData = this.createData();
+    final Procedure1<short[]> _function = (short[] it) -> {
+      it[1] = ((short) 0);
+    };
+    final short[] newData = ObjectExtensions.<short[]>operator_doubleArrow(_createData, _function);
+    Assert.assertFalse(this.data.equals(newData));
+  }
+  
+  @Test
+  public void testContains__short() {
+    Assert.assertTrue(ArrayExtensions.contains(this.data, ((short) 10)));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, ((short) 20)));
+    Assert.assertTrue(ArrayExtensions.contains(this.data, ((short) 30)));
+    Assert.assertFalse(ArrayExtensions.contains(this.data, ((short) 40)));
+  }
+}

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/ArrayExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/ArrayExtensions.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.lib;
 
+import java.util.Objects;
+
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 /**
@@ -110,6 +112,29 @@ public class ArrayExtensions {
 	}
 	
 	/**
+	 * Returns whether the array contains the given element.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param o 
+	 * 			element whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static <T> boolean contains(Object[] array, Object o) {
+		for (int i = 0; i < array.length; i++) {
+			if (Objects.equals(array[i], o)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
 	 * @param array
 	 *            the array
 	 * @param index
@@ -193,6 +218,27 @@ public class ArrayExtensions {
 	@GwtIncompatible("clone")
 	public static boolean[] clone(boolean[] array) {
 		return array.clone();
+	}
+	
+	/**
+	 * Returns whether the array contains the given value. More formally,
+	 * returns <tt>true</tt> if and only if this array contains at least one
+	 * element <tt>e</tt> such that <tt>value==e</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param value 
+	 * 			value whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(boolean[] array, boolean value) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] == value) {
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	/**
@@ -282,6 +328,29 @@ public class ArrayExtensions {
 	}
 	
 	/**
+	 * Returns whether the array contains the given value.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>java.lang.Double.compare(o,&nbsp;e)&nbsp;==&nbsp;0)</tt>.
+	 * 
+	 * @param array 
+	 * 			the array to test
+	 * @param value 
+	 * 			value whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(double[] array, double value) {
+		for (int i = 0; i < array.length; i++) {
+			if (Double.compare(array[i], value) == 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
 	 * @param array
 	 *            the array
 	 * @param index
@@ -365,6 +434,29 @@ public class ArrayExtensions {
 	@GwtIncompatible("clone")
 	public static float[] clone(float[] array) {
 		return array.clone();
+	}
+	
+	/**
+	 * Returns whether the array contains the given value.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>java.lang.Float.compare(o,&nbsp;e)&nbsp;==&nbsp;0)</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param value 
+	 * 			value whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(float[] array, float value) {
+		for (int i = 0; i < array.length; i++) {
+			if (Float.compare(array[i], value) == 0) {
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	/**
@@ -454,6 +546,29 @@ public class ArrayExtensions {
 	}
 	
 	/**
+	 * Returns whether the array contains the given value.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>(value&nbsp;==&nbsp;e)</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param o 
+	 * 			element whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(long[] array, long value) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] == value) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
 	 * @param array
 	 *            the array
 	 * @param index
@@ -537,6 +652,29 @@ public class ArrayExtensions {
 	@GwtIncompatible("clone")
 	public static int[] clone(int[] array) {
 		return array.clone();
+	}
+	
+	/**
+	 * Returns whether the array contains the given value.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>(value&nbsp;==&nbsp;e)</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param value 
+	 * 			value whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(int[] array, int value) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] == value) {
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	/**
@@ -626,6 +764,29 @@ public class ArrayExtensions {
 	}
 	
 	/**
+	 * Returns whether the array contains the given value.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>(value&nbsp;==&nbsp;e)</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param value 
+	 * 			value whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(char[] array, char value) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] == value) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
 	 * @param array
 	 *            the array
 	 * @param index
@@ -712,6 +873,29 @@ public class ArrayExtensions {
 	}
 	
 	/**
+	 * Returns whether the array contains the given value.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>(value&nbsp;==&nbsp;e)</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param value 
+	 * 			value whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(short[] array, short value) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] == value) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
 	 * @param array
 	 *            the array
 	 * @param index
@@ -795,6 +979,29 @@ public class ArrayExtensions {
 	@GwtIncompatible("clone")
 	public static byte[] clone(byte[] array) {
 		return array.clone();
+	}
+	
+	/**
+	 * Returns whether the array contains the given value.
+	 * 
+	 * More formally, returns <tt>true</tt> if and only if this array contains
+	 * at least one element <tt>e</tt> such that
+	 * <tt>(value&nbsp;==&nbsp;e)</tt>.
+	 *
+	 * @param array 
+	 * 			the array to test
+	 * @param value 
+	 * 			value whose presence in this array is to be tested
+	 * @return <tt>true</tt> if this array contains the specified element
+	 */
+	@Pure
+	public static boolean contains(byte[] array, byte value) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] == value) {
+				return true;
+			}
+		}
+		return false;
 	}
 // END generated code
 

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -977,4 +977,23 @@ public class IterableExtensions {
 	public static <T> T max(final Iterable<T> iterable, Comparator<? super T> comparator) {
 		return IteratorExtensions.max(iterable.iterator(), comparator);
 	}
+
+    /**
+     * Returns <tt>true</tt> if this Iterable contains the specified element.
+     * More formally, returns <tt>true</tt> if and only if this Iterable contains
+     * at least one element <tt>e</tt> such that
+     * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+     *
+     * @param iterable 
+     * 			the elements to test
+     * @param o 
+     * 			element whose presence in the Iterable is to be tested
+     * @return <tt>true</tt> if this Iterable contains the specified element
+     */
+	public static boolean contains(Iterable<?> iterable, Object o) {
+		if (iterable instanceof Collection<?>) {
+			return ((Collection<?>) iterable).contains(o);
+		}
+		return IteratorExtensions.contains(iterable.iterator(), o);
+	}
 }

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -249,6 +250,8 @@ import com.google.common.collect.Sets;
 
 	/**
 	 * Returns {@code true} if one or more elements in {@code iterator} satisfy the predicate.
+	 * 
+     * <p>Note that this will advance or even exhaust the given iterator.</p>
 	 * 
 	 * @param iterator
 	 *            the iterator. May not be <code>null</code>.
@@ -553,6 +556,8 @@ import com.google.common.collect.Sets;
 	 * {@code true} if {@code iterator} and {@code other} contain the same number of elements and every element of
 	 * {@code iterator} is equal to the corresponding element of {@code other}.
 	 * 
+	 * <p>Note that this will advance or even exhaust the given iterators.</p>
+	 * 
 	 * @param iterator
 	 *            an iterator. May not be <code>null</code>.
 	 * @param other
@@ -567,6 +572,8 @@ import com.google.common.collect.Sets;
 	 * Determines whether two iterators contain equal elements in the same order. More specifically, this method returns
 	 * {@code true} if {@code iterator} and {@code iterable} contain the same number of elements and every element of
 	 * {@code iterator} is equal to the corresponding element of {@code iterable}.
+	 * 
+	 * <p>Note that this will advance or even exhaust the given iterators.</p>
 	 * 
 	 * @param iterator
 	 *            an iterator. May not be <code>null</code>.
@@ -932,6 +939,8 @@ import com.google.common.collect.Sets;
 	 * Finds the minimum of the given elements according to their natural ordering. If there are several mimina, the
 	 * first one will be returned.
 	 * 
+	 * <p>Note that this will advance or even exhaust the given iterator.</p>
+	 * 
 	 * @param iterator
 	 *            the mutually comparable elements. May not be <code>null</code>.
 	 * @return the minimum
@@ -946,6 +955,8 @@ import com.google.common.collect.Sets;
 	/**
 	 * Finds the element that yields the minimum value when passed to <code>compareBy</code>. If there are several
 	 * maxima, the first one will be returned.
+	 * 
+	 * <p>Note that this will advance or even exhaust the given iterator.</p>
 	 * 
 	 * @param iterator
 	 *            the elements to find the minimum of. May not be <code>null</code>.
@@ -965,6 +976,8 @@ import com.google.common.collect.Sets;
 	/**
 	 * Finds the mininmum element according to <code>comparator</code>. If there are several minima, the first one will
 	 * be returned.
+	 * 
+	 * <p>Note that this will advance or even exhaust the given iterator.</p>
 	 * 
 	 * @param iterator
 	 *            the elements to find the minimum of. May not be <code>null</code>.
@@ -990,6 +1003,8 @@ import com.google.common.collect.Sets;
 	 * Finds the maximum of the elements according to their natural ordering. If there are several maxima, the first one
 	 * will be returned.
 	 * 
+     * <p>Note that this will advance or even exhaust the given iterator.</p>
+     * 
 	 * @param iterator
 	 *            the mutually comparable elements. May not be <code>null</code>.
 	 * @return the maximum
@@ -1004,6 +1019,8 @@ import com.google.common.collect.Sets;
 	/**
 	 * Finds the element that yields the maximum value when passed to <code>compareBy</code> If there are several
 	 * maxima, the first one will be returned.
+	 * 
+	 * <p>Note that this will advance or even exhaust the given iterator.</p>
 	 * 
 	 * @param iterator
 	 *            the elements to find the maximum of. May not be <code>null</code>.
@@ -1024,6 +1041,8 @@ import com.google.common.collect.Sets;
 	 * Finds the maximum element according to <code>comparator</code>. If there are several maxima, the first one will
 	 * be returned.
 	 * 
+	 * <p>Note that this will advance or even exhaust the given iterator.</p>
+	 * 
 	 * @param iterator
 	 *            the elements to find the maximum of. May not be <code>null</code>.
 	 * @param comparator
@@ -1042,5 +1061,30 @@ import com.google.common.collect.Sets;
 			max = comparator.compare(max, element) >= 0 ? max : element;
 		}
 		return max;
+	}
+
+	/**
+	 * Returns <tt>true</tt> if this Iterator contains the specified element.
+	 * More formally, returns <tt>true</tt> if and only if this Iterator
+	 * contains at least one element <tt>e</tt> such that
+	 * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+	 * 
+	 * <p>
+	 * Note that this will advance or even exhaust the given iterator.
+	 * </p>
+	 *
+	 * @param iterable 
+	 * 			the elements to test
+	 * @param o 
+	 * 			element whose presence in this Iterator is to be tested
+	 * @return <tt>true</tt> if this Iterator contains the specified element
+	 */
+	public static boolean contains(Iterator<?> iterator, Object o) {
+		while (iterator.hasNext()) {
+			if (Objects.equals(o, iterator.next())) {
+				return true;
+			}
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
added a contains method to arrayExtensions for Object and all scalar
datatypes as well as for Iterables and Iterators. It uses
java.lang.Objects.equals(...) where applicable.

Furthermore I added tests for the different ArrayExtension methods

Signed-off-by: Mathias Rieder <mathias.rieder@gmail.com>