### PR TITLE
[eclipse/xtext#1537] bootstrap against 2.19.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@
 version = '2.20.0-SNAPSHOT'
 
 ext.versions = [
-	'xtext_bootstrap': '2.19.0.M3',
+	'xtext_bootstrap': '2.19.0',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '2.0.7',
 	'dependency_management_plugin' : '1.0.8.RELEASE',


### PR DESCRIPTION
[eclipse/xtext#1537] bootstrap against 2.19.0
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>