### PR TITLE
Add mwe.core to xtext-dev-bom

### DIFF
--- a/releng/org.eclipse.xtext.dev-bom/pom.xml
+++ b/releng/org.eclipse.xtext.dev-bom/pom.xml
@@ -47,6 +47,12 @@
 			<organization>itemis</organization>
 			<organizationUrl>http://www.itemis.com</organizationUrl>
 		</developer>
+		<developer>
+			<id>lorenzo.bettini</id>
+			<name>Lorenzo Bettini</name>
+			<email>lorenzo.bettini@gmail.com</email>
+			<organization>DISIA, University Firenze</organization>
+		</developer>
 	</developers>
 	<scm>
 		<connection>scm:git:git@github.com:eclipse/xtext-lib.git</connection>
@@ -242,6 +248,11 @@
 			<dependency>
 				<groupId>org.eclipse.emf</groupId>
 				<artifactId>org.eclipse.emf.mwe.utils</artifactId>
+				<version>${emf.mwe-version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.emf</groupId>
+				<artifactId>org.eclipse.emf.mwe.core</artifactId>
 				<version>${emf.mwe-version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
As noted here https://www.eclipse.org/forums/index.php/t/1101550/ `mwe.core` is not dragged in automatically anymore in Maven builds, and must be explicitly added. If one relies on the xtext-dev-bom it would be nice to add mwe.core to the BOM

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>