### PR TITLE
Fix javadoc warnings in ArrayExtensions and IteratorExtensions classes.

### DIFF
--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/ArrayExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/ArrayExtensions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -554,7 +554,7 @@ public class ArrayExtensions {
 	 *
 	 * @param array 
 	 * 			the array to test
-	 * @param o 
+	 * @param value 
 	 * 			element whose presence in this array is to be tested
 	 * @return <tt>true</tt> if this array contains the specified element
 	 */

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1073,7 +1073,7 @@ import com.google.common.collect.Sets;
 	 * Note that this will advance or even exhaust the given iterator.
 	 * </p>
 	 *
-	 * @param iterable 
+	 * @param iterator 
 	 * 			the elements to test
 	 * @param o 
 	 * 			element whose presence in this Iterator is to be tested


### PR DESCRIPTION
- > Task :org.eclipse.xtext.xbase.lib:javadoc
C:\Users\miklossy\git\xtext-lib\org.eclipse.xtext.xbase.lib\src\org\eclipse\xtext\xbase\lib\ArrayExtensions.java:562:
warning - @param argument "o" is not a parameter name.
C:\Users\miklossy\git\xtext-lib\org.eclipse.xtext.xbase.lib\src\org\eclipse\xtext\xbase\lib\IteratorExtensions.java:1082:
warning - @param argument "iterable" is not a parameter name.
2 warnings

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>