### PR TITLE
[eclipse/xtext-xtend#903] Overhaul Accessors Annotation

### DIFF
--- a/org.eclipse.xtend.lib.macro/src/org/eclipse/xtend/lib/macro/declaration/MethodDeclaration.java
+++ b/org.eclipse.xtend.lib.macro/src/org/eclipse/xtend/lib/macro/declaration/MethodDeclaration.java
@@ -59,10 +59,14 @@ public interface MethodDeclaration extends ExecutableDeclaration {
 	 * @return whether this method is declared <code>native</code>
 	 */
 	boolean isNative();
-
 	
 	/**
 	 * @return the return type of this method
 	 */
 	TypeReference getReturnType();
+	
+	/**
+	 * @return the overridden or implemented methods
+	 */
+	Iterable<? extends MethodDeclaration> getOverriddenOrImplementedMethods();
 }

--- a/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/Accessors.java
+++ b/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/Accessors.java
@@ -1,10 +1,20 @@
+/**
+ * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.xtend.lib.annotations;
 
+import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import org.eclipse.xtend.lib.annotations.AccessorType;
+import org.eclipse.xtend.lib.annotations.AccessorsDeprecationPolicy;
 import org.eclipse.xtend.lib.annotations.AccessorsProcessor;
 import org.eclipse.xtend.lib.macro.Active;
 
@@ -18,6 +28,8 @@ import org.eclipse.xtend.lib.macro.Active;
  * <li>By default the accessors are public</li>
  * <li>If the {@link AccessorType}[] argument is given, only the listed
  * accessors with the specified visibility will be generated</li>
+ * <li>By default the accessors will be deprecated if the field is annotated as such.
+ * This can be changed by explicitly providing {@link Accessors#deprecationPolicy deprecationPolicy}</li>
  * </ul>
  * </p>
  * <p>
@@ -47,4 +59,11 @@ public @interface Accessors {
    * Accessors may be suppressed by passing {@link AccessorType#NONE}.
    */
   public AccessorType[] value() default { AccessorType.PUBLIC_GETTER, AccessorType.PUBLIC_SETTER };
+  /**
+   * Describes when {@code @Deprecated} will be added to generated accessors.<br>
+   * If it is not wanted or needed, pass {@link AccessorsDeprecationPolicy#NEVER} to prevent the annotation from being added.
+   * @since 2.23
+   */
+  @Beta
+  public AccessorsDeprecationPolicy deprecationPolicy() default AccessorsDeprecationPolicy.SAME_AS_FIELD;
 }

--- a/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/AccessorsDeprecationPolicy.java
+++ b/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/AccessorsDeprecationPolicy.java
@@ -12,28 +12,19 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 
 /**
- * @since 2.7
- * @noreference
+ * @since 2.23
  */
 @Beta
 @GwtCompatible
 @SuppressWarnings("all")
-public enum AccessorType {
-  PUBLIC_GETTER,
+public enum AccessorsDeprecationPolicy {
+  SAME_AS_FIELD,
   
-  PROTECTED_GETTER,
+  ONLY_GETTER,
   
-  PACKAGE_GETTER,
+  ONLY_SETTER,
   
-  PRIVATE_GETTER,
+  ALWAYS,
   
-  PUBLIC_SETTER,
-  
-  PROTECTED_SETTER,
-  
-  PACKAGE_SETTER,
-  
-  PRIVATE_SETTER,
-  
-  NONE;
+  NEVER;
 }


### PR DESCRIPTION
The `@Accessors` can now delegate annotations to the getters.
The annotation detects deprecated fields and generates `@Deprecated` when required. It is an error to set any of the deprecation fields on the annotation when the field is already deprecated (checked by the Java compiler, not by the annotation processor).
The setter can be set to return `this`.
The annotation can delegate warning types to suppress.
Classes may declare a "custom getter" by annotating one instance method with `@CustomGetter`. Such methods have to take no arguments and cannot be static, and cannot return void. (The void method validation is done by the Java compiler, not by the annotation processor). When a class uses a custom getter, an additional method is generated for annotated fields of that type: a "raw" getter, which _always_ returns the field (has the same name as the getter, but with `Raw` between the prefix and the field name). Note that settings of the getter and the raw getter set via the annotation are not shared.

Signed-off-by Iván Nieves &lt;ivaniesta14 at gmail dot com>