### PR TITLE
Upgrade classgraph from 4.8.35 to 4.8.88

### DIFF
--- a/org.eclipse.xtext.dev-bom/build.gradle
+++ b/org.eclipse.xtext.dev-bom/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         api "com.google.guava:guava-testlib:27.1-jre"
         api "com.google.guava:guava:27.1-jre"
         api "com.google.inject:guice:3.0"
-        api "io.github.classgraph:classgraph:4.8.35"
+        api "io.github.classgraph:classgraph:4.8.88"
         api "javax.annotation:javax.annotation-api:1.3.2"
         api "junit:junit:4.12"
         api "log4j:log4j:1.2.17"


### PR DESCRIPTION
Upgrade [classgraph](https://github.com/classgraph/classgraph) from
4.8.35 to 4.8.88.
- [Release notes](https://github.com/classgraph/classgraph/releases)
- [Commits](classgraph/classgraph@classgraph-4.8.35...classgraph-4.8.88)

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>