### PR TITLE
bump gwt gradle plugin to avoid gradle 8.0 deprecation warnings

### DIFF
--- a/org.eclipse.xtend.lib.gwt.test/build.gradle
+++ b/org.eclipse.xtend.lib.gwt.test/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-     id "org.wisepersist.gwt" version "1.1.14"
+     id "org.wisepersist.gwt" version "1.1.15"
 }
 
 group = 'org.eclipse.xtend'


### PR DESCRIPTION
bump gwt gradle plugin to avoid gradle 8.0 deprecation warnings
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>