### PR TITLE
use https in dtd link to avoid validation error in eclipse

### DIFF
--- a/org.eclipse.xtend.lib.gwt.test/src/org/eclipse/xtend/lib/test/Test.gwt.xml
+++ b/org.eclipse.xtend.lib.gwt.test/src/org/eclipse/xtend/lib/test/Test.gwt.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.2//EN" "http://www.gwtproject.org/doctype/2.8.2/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.2//EN" "https://www.gwtproject.org/doctype/2.8.2/gwt-module.dtd">
 <module>
   <inherits name="org.eclipse.xtend.lib.Lib" />
   <source path="">


### PR DESCRIPTION
use https in dtd link to avoid validation error in eclipse