### PR TITLE
added missing pinned version of mwe2.language in BOM

### DIFF
--- a/org.eclipse.xtext.dev-bom/build.gradle
+++ b/org.eclipse.xtext.dev-bom/build.gradle
@@ -37,6 +37,7 @@ dependencies {
         api "org.eclipse.emf:org.eclipse.emf.mwe2.launch:2.14.0.M1"
         api "org.eclipse.emf:org.eclipse.emf.mwe2.lib:2.14.0.M1"
         api "org.eclipse.emf:org.eclipse.emf.mwe2.runtime:2.14.0.M1"
+        api "org.eclipse.emf:org.eclipse.emf.mwe2.language:2.14.0.M1"
         api "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:1.4.200"
         api "org.eclipse.jdt:org.eclipse.jdt.compiler.tool:1.3.200"
         api "org.eclipse.jdt:org.eclipse.jdt.core:3.31.0"


### PR DESCRIPTION
I think it was not intentional that mwe2.language version was not part of the BOM

This might be related to https://github.com/eclipse/xtext/issues/2397

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>